### PR TITLE
add do-not-edit comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,11 +7,17 @@ A longer description and justification for the changes.
 Raise any areas of concern.
 
 
-<!-- please do not edit below this line -->
+
+<!--
+  Text below provides an easy link for PR reviewers to click.
+  After submitting your request, change the `[live-site]:` URL
+  at the end with the actual `{pull-request-number}` assigned
+  by GitHub, without the '#'.
+-->
 
 These changes can be [viewed live][live-site].
 
-**Remember to tear down the [live site][live-site] when merging or
-  closing this pull-request.**
+**Remember to tear down the [live site][live-site] when merging
+or closing this pull request.**
 
 [live-site]: http://random-cat-{pull-request-number}.surge.sh

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,6 +6,9 @@ A longer description and justification for the changes.
 
 Raise any areas of concern.
 
+
+<!-- please do not edit below this line -->
+
 These changes can be [viewed live][live-site].
 
 **Remember to tear down the [live site][live-site] when merging or


### PR DESCRIPTION
**Preserve surge links even if scrapping the template**

Requesters may reflexively delete PR template text. This change adds an HTML comment requesting that they preserve the surge.sh template language, as it is important to the review process.

The comment should be invisible in the rendered markdown, but will be visible to authors and editors.

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging or
  closing this pull-request.**

[live-site]: http://random-cat-{pull-request-number}.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/682)
<!-- Reviewable:end -->
