### PR TITLE
Ensure bad simulation result names do not display

### DIFF
--- a/_includes/simulation.html
+++ b/_includes/simulation.html
@@ -108,7 +108,7 @@
 <script>
   var SIM_NAME = new URL(window.location.href).searchParams.get("sim");
   var CHART_DATA={{ site.data.charts.plot1d | jsonify }};
-  var DATA={{ site.data.simulations | jsonify }}[SIM_NAME].meta;
+  var ALL_DATA={{ site.data.simulations | jsonify }};
   var CODES_DATA={{ site.data.codes | jsonify }};
 </script>
 

--- a/js/simulation.coffee
+++ b/js/simulation.coffee
@@ -6,4 +6,7 @@
 {% include coffee/vega_extra.coffee %}
 {% include coffee/simulation.coffee %}
 
-build(DATA, SIM_NAME, CODES_DATA, CHART_DATA)
+if SIM_NAME of ALL_DATA
+  build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA)
+else
+  window.location = "{{ site.baseurl }}/simulations/notfound/?sim=" + SIM_NAME

--- a/simulations/notfound.html
+++ b/simulations/notfound.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+
+<div class="container">
+  <div class="row top-buffer">
+    <div class="col s12">
+      <div class="flow-text">
+        The parameter, <span id="sim_name"></span>, is not a valid
+        simulation result name, see
+        <a href="{{ site.baseurl }}/simulations/#simulations">
+          the full table of simulation results
+        </a>
+        to select a valid simulation result to display.
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  var SIM_NAME = new URL(window.location.href).searchParams.get("sim");
+  $('#sim_name').html(SIM_NAME);
+</script>

--- a/simulations/notfound.html
+++ b/simulations/notfound.html
@@ -6,12 +6,13 @@ layout: default
   <div class="row top-buffer">
     <div class="col s12">
       <div class="flow-text">
-        The parameter, <span id="sim_name"></span>, is not a valid
-        simulation result name, see
-        <a href="{{ site.baseurl }}/simulations/#simulations">
-          the full table of simulation results
-        </a>
-        to select a valid simulation result to display.
+        <p>
+          The simulation result named <i><span id="sim_name"></span></i> has not yet been uploaded.
+        </p>
+        <p>
+          Please visit <a href="{{ site.baseurl }}/simulations/#simulations">the table of simulations results</a> for a valid list of names,
+          or proceed to <a href="{{ site.baseurl }}/simulations/upload_form/">upload</a> a new one.
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Address #694

Ensure that non-existent simulation names don't display on the
simulation result landing page.

For example, https://pages.nist.gov/pfhub/simulations/display/?sim=blah will show a broken landing page with "blah" as the title, but now this should be better, http://random-cat-701.surge.sh/simulations/display/?sim=blah

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-701.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/701)
<!-- Reviewable:end -->
