### PR TITLE
Implement custom submission page

### DIFF
--- a/_includes/data_input.html
+++ b/_includes/data_input.html
@@ -20,8 +20,8 @@
            name="fields[data][{{ counter }}][name]"
            type="text"
            class="validate"
-           length="32"
-           pattern="^[\w]{2,32}$">
+           length="64"
+           pattern="^[\\w]{2,64}$">
     <label for="data-name-{{ counter }}">
       Short name of data
     </label>
@@ -94,7 +94,7 @@
              name="fields[data][{{ ../counter }}][format][parse]"
              type="text"
              class="validate field-input-{{this.[0]}}-{{../counter}}"
-             length="32">
+             length="64">
       <label for="data-{{this.[0]}}-parse-{{ ../counter }}">
         Name of {{this.[0]}}-axis column
       </label>

--- a/_includes/form_overview.html
+++ b/_includes/form_overview.html
@@ -13,8 +13,8 @@
            name="options[simulation_name]"
            class="validate"
            type="text"
-	   length="32"
-           pattern="^[\w]{2,32}$">
+	   length="64"
+           pattern="^[\w]{2,64}$">
     <label for="simulation_name">
       Short Name
     </label>

--- a/_includes/media_input.html
+++ b/_includes/media_input.html
@@ -19,8 +19,8 @@
            name="fields[data][{{ counter }}][name]"
            type="text"
            class="validate"
-           length="32"
-           pattern="^[\w]{2,32}$">
+           length="64"
+           pattern="^[\\w]{2,64}$">
     <label for="data-name-{{ counter }}">
       Short name of media data
     </label>

--- a/simulations/submit.html
+++ b/simulations/submit.html
@@ -6,16 +6,19 @@ layout: default
   <div class="row top-buffer">
     <div class="col s12">
       <div class="flow-text">
-        Thanks for submitting a new simulation result. The submission will
-        be reviewed via a pull request on GitHub and is awaiting
-        approval by the
-        <a href="mailto:{{ site.admin_email }}">moderators</a>. Please
-        go to <a href="{{ site.links.github }}/pulls">{{
-        site.links.github }}/pulls</a> to view the pull
-        request. The <a href="mailto:{{ site.admin_email
-        }}">moderators</a> will contact you via GitHub if there are
-        any problems with the submission. Instructions for viewing
-        your submission are available in the pull request.
+        <p>
+          Thanks for submitting a new simulation result. The
+          submission will be reviewed via a pull request on GitHub and
+          is awaiting approval by the
+          <a href="mailto:{{ site.admin_email }}">moderators</a>.
+        </p>
+        <p>
+          Please go to <a href="{{ site.links.github }}/pulls">{{
+          site.links.github }}/pulls</a> to view the pull
+          request. The <a href="mailto:{{ site.admin_email
+          }}">moderators</a> will contact you via GitHub if there are
+          any problems with the submission. Instructions for viewing
+          your submission are available in the pull request.
       </div>
     </div>
   </div>

--- a/simulations/submit.html
+++ b/simulations/submit.html
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+
+<div class="container">
+  <div class="row top-buffer">
+    <div class="col s12">
+      <div class="flow-text">
+        Thanks for submitting a new simulation result. The submission will
+        be reviewed via a pull request on GitHub and is awaiting
+        approval by the
+        <a href="mailto:{{ site.admin_email }}">moderators</a>. Please
+        go to <a href="{{ site.links.github }}/pulls">{{
+        site.links.github }}/pulls</a> to view the pull
+        request. The <a href="mailto:{{ site.admin_email
+        }}">moderators</a> will contact you via GitHub if there are
+        any problems with the submission. Instructions for viewing
+        your submission are available in the pull request.
+      </div>
+    </div>
+  </div>
+</div>

--- a/simulations/upload_form.html
+++ b/simulations/upload_form.html
@@ -46,7 +46,7 @@ layout: default
             action="{{ site.links.staticman_api }}">
         <input name="options[redirect]"
                type="hidden"
-               value="{{ site.links.github }}/pulls">
+               value="{{ site.url }}/{{ site.baseurl }}/simulations/submit">
 
         {% include form_author.html %}
         {% include form_overview.html %}


### PR DESCRIPTION
Address #693

Implement a custom submission page which is viewed after submitting a
simulation result in place of just jumping to the GitHub pull request
page.

The custom submission page can be viewed at http://random-cat-707.surge.sh/simulations/submit

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-707.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/707)
<!-- Reviewable:end -->
