### PR TITLE
fix transposed B1 and A2 parameters in BM7 as well as a typo in the appendix

### DIFF
--- a/benchmarks/benchmark7.ipynb
+++ b/benchmarks/benchmark7.ipynb
@@ -269,8 +269,8 @@
     "|-----------|-------|\n",
     "| $\\kappa$  | 0.0004|\n",
     "| $A_1$     | 0.0075|\n",
-    "| $B_1$     | 0.03  |\n",
-    "| $A_2$     | 8.0   |\n",
+    "| $B_1$     | 8.0  |\n",
+    "| $A_2$     | 0.03   |\n",
     "| $B_2$     | 22.0  |\n",
     "| $C_2$     | 0.0625|"
    ]
@@ -356,7 +356,7 @@
     "# Appendix\n",
     "\n",
     "## Computer algebra systems\n",
-    "Rigorous verification of software frameworks using MMS requires posing the equation and manufacturing the solution with as much complexity as possible. This can be straight-forward, but interesting equations produce complicated source terms. To streamline the MMS workflow, it is strongly recommended that you use a CAS such as SymPy, Maple, or Mathematica to generate source equations and turn it into executable code automatically. For accessibility, we will use [SymPy](http://www.sympy.org/), but so long as vector calculus is supported, and CAS will do."
+    "Rigorous verification of software frameworks using MMS requires posing the equation and manufacturing the solution with as much complexity as possible. This can be straight-forward, but interesting equations produce complicated source terms. To streamline the MMS workflow, it is strongly recommended that you use a CAS such as SymPy, Maple, or Mathematica to generate source equations and turn it into executable code automatically. For accessibility, we will use [SymPy](http://www.sympy.org/), but so long as vector calculus is supported, CAS will do."
    ]
   },
   {


### PR DESCRIPTION
Fix two typos in BM7, one critical (mixed up parameter values) and one less so (typo in the appendix text).

Fixes #719 and #720

A longer description and justification for the changes.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-721.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/721)
<!-- Reviewable:end -->
