### PR TITLE
Use hardwired link for submission page

### DIFF
--- a/simulations/upload_form.html
+++ b/simulations/upload_form.html
@@ -46,7 +46,7 @@ layout: default
             action="{{ site.links.staticman_api }}">
         <input name="options[redirect]"
                type="hidden"
-               value="{{ site.url }}/{{ site.baseurl }}/simulations/submit">
+               value="{{ site.links.live_url }}/simulations/submit">
 
         {% include form_author.html %}
         {% include form_overview.html %}


### PR DESCRIPTION
Fixes #724

The submission page is redirected from Staticman so can't be a
relative link and `site.url` appears to be broken on pages.nist.gov.

The submission page will always be the one on pages.nist.gov at the moment until site.url works correctly on pages.nist.gov.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-726.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/726)
<!-- Reviewable:end -->
