### PR TITLE
dedication to the public domain

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,31 @@
-The MIT License (MIT)
+Public Domain
 
-Copyright (c) 2015 Daniel Wheeler
+This software was developed by employees of the
+[National Institute of Standards and Technology](http://www.nist.gov),
+an agency of the Federal Government. Pursuant to
+[title 17 section 105](https://www.copyright.gov/title17/92chap1.html#105)
+of the United States Code, works of NIST employees are not subject to
+copyright protection in the United States and are considered to be in
+the public domain. NIST assumes no responsibility whatsoever for the
+use of this software by other parties, and makes no guarantees, expressed or
+implied, about its quality, reliability, or any other characteristic.
+We would appreciate acknowledgement if the software is used.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+To the extent that NIST may hold copyright in countries other than the
+United States, you are hereby granted the non-exclusive irrevocable
+and unconditional right to print, publish, prepare derivative works and
+distribute this software, in any medium, or authorize others to do so
+on your behalf, on a royalty-free basis throughout the world.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+You may improve, modify, and create derivative works of the software or any
+portion of the software, and you may copy and distribute such modifications
+or works. Modified works should carry a notice stating that you changed
+the software and should note the date and nature of any such change. Please
+explicitly acknowledge the National Institute of Standards and Technology
+as the original source, by linking back to
+[this repository](https://github.com/usnistgov/pfhub) or
+[the website](https://pages.nist.gov/pfhub).
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+This software can be redistributed and/or modified freely provided that any
+derivative works bear some notice that they are derived from it, and any
+modified versions bear some notice that they have been modified.


### PR DESCRIPTION
**Dedicate PFHub Source Code to the Public Domain**

Fixes #730.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-731.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/731)
<!-- Reviewable:end -->
