### PR TITLE
Fipy 3a

### DIFF
--- a/_data/axes_names.yaml
+++ b/_data/axes_names.yaml
@@ -1,0 +1,16 @@
+- name: free_energy
+  x_title: Time
+  y_title: Free Energy
+  x_scale: log
+  y_scale: log
+  minimum: 0.01
+- name: solid_fraction
+  y_title: Solid Fraction
+  x_title: Time
+  x_scale: linear
+  y_scale: linear
+- name: tip_position
+  y_title: Tip Position
+  x_title: Time
+  x_scale: linear
+  y_scale: linear

--- a/_data/simulations/fipy_3a/meta.yaml
+++ b/_data/simulations/fipy_3a/meta.yaml
@@ -35,7 +35,7 @@ data:
       - unit: KB
         value: '2000000'
   - name: free_energy
-    url: 'https://ndownloader.figshare.com/files/10420491'
+    url: 'https://ndownloader.figshare.com/files/10443456'
     format:
       type: csv
       parse:
@@ -51,7 +51,7 @@ data:
         expr: datum.free_energy
         as: 'y'
   - name: solid_fraction
-    url: 'https://ndownloader.figshare.com/files/10420491'
+    url: 'https://ndownloader.figshare.com/files/10443456'
     format:
       type: csv
       parse:
@@ -67,7 +67,7 @@ data:
         expr: datum.solid_fraction
         as: 'y'
   - name: tip_position
-    url: 'https://ndownloader.figshare.com/files/10420491'
+    url: 'https://ndownloader.figshare.com/files/10443456'
     format:
       type: csv
       parse:

--- a/_includes/coffee/simulation.coffee
+++ b/_includes/coffee/simulation.coffee
@@ -462,7 +462,7 @@ ploterize = (data) ->
   return data
 
 
-build = (data, sim_name, codes_data, chart_data) ->
+build = (data, sim_name, codes_data, chart_data, axes_names) ->
   ### Build the simulation landing page
 
   Args:
@@ -483,7 +483,7 @@ build = (data, sim_name, codes_data, chart_data) ->
   results_table(data)
 
   result_data = groupBy(((x) -> x.type), data.data)
-  vega_data = vegarize(chart_data)(result_data.line)
+  vega_data = vegarize(chart_data, axes_names)(result_data.line)
 
   if result_data.image?
     add_card(add_image, '#logo_image', with_div = id)(result_data.image[0..0])

--- a/_includes/coffee/vega_extra.coffee
+++ b/_includes/coffee/vega_extra.coffee
@@ -3,7 +3,7 @@ Extra functions to build and parse Vega charts
 ###
 
 
-update_vega_data = (data) ->
+update_vega_data = (axes_names, data) ->
   ### Update chart data depending on name of the data
 
   Args:
@@ -13,14 +13,20 @@ update_vega_data = (data) ->
     the updated data
   ###
   x = copy_(data)
-  if x.data[0].name is 'free_energy'
-    x.axes[0].title = 'Time'
-    x.axes[1].title = 'Free Energy'
-    x.scales[0].type = 'log'
-    x.scales[1].type = 'log'
-    x.data[0].transform.push({expr:'datum.x > 0.01', type:'filter'})
+  axes_data = axes_names.filter((y) -> y.name is x.data[0].name)
+  if axes_data.length > 0
+    x.axes[0].title = axes_data[0].x_title
+    x.axes[1].title = axes_data[0].y_title
+    x.scales[0].type = axes_data[0].x_scale
+    x.scales[1].type = axes_data[0].y_scale
+    if axes_data[0].minimum?
+      x.data[0].transform.push(
+        {expr:'datum.x > ' + axes_data[0].minimum, type:'filter'}
+      )
   x.data[0].name = 'the_data'
+  console.log(x)
   x
+
 
 
 combine_vega_data = curry(
@@ -31,7 +37,7 @@ combine_vega_data = curry(
 )
 
 
-vegarize = (chart_data) ->
+vegarize = (chart_data, axes_names) ->
   ### Generate function to combine a Vega plot and its data
 
   Args:
@@ -42,7 +48,7 @@ vegarize = (chart_data) ->
   ###
   sequence(
     map(combine_vega_data(chart_data)),
-    map(update_vega_data)
+    map((x) -> update_vega_data(axes_names, x))
   )
 
 

--- a/_includes/coffee/vega_extra.coffee
+++ b/_includes/coffee/vega_extra.coffee
@@ -24,7 +24,6 @@ update_vega_data = (axes_names, data) ->
         {expr:'datum.x > ' + axes_data[0].minimum, type:'filter'}
       )
   x.data[0].name = 'the_data'
-  console.log(x)
   x
 
 

--- a/_includes/simulation.html
+++ b/_includes/simulation.html
@@ -110,6 +110,7 @@
   var CHART_DATA={{ site.data.charts.plot1d | jsonify }};
   var ALL_DATA={{ site.data.simulations | jsonify }};
   var CODES_DATA={{ site.data.codes | jsonify }};
+  var AXES_NAMES={{ site.data.axes_names | jsonify }};
 </script>
 
 <script src="{{ site.baseurl }}/js/simulation.js"></script>

--- a/js/simulation.coffee
+++ b/js/simulation.coffee
@@ -7,6 +7,6 @@
 {% include coffee/simulation.coffee %}
 
 if SIM_NAME of ALL_DATA
-  build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA)
+  build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA, AXES_NAMES)
 else
   window.location = "{{ site.baseurl }}/simulations/notfound/?sim=" + SIM_NAME


### PR DESCRIPTION
Fix fipy_3a upload
 
 - implement axes names for solid fraction and tip position and a generic way to handle other named data

 - update solid fraction data for fipy_3a to be the actual fraction

See,

http://random-cat-735.surge.sh/simulations/display/?sim=fipy_3a

to review.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-735.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/735)
<!-- Reviewable:end -->
