### PR TITLE
fixed errors in BM7 notebook

### DIFF
--- a/benchmarks/benchmark7.ipynb
+++ b/benchmarks/benchmark7.ipynb
@@ -247,7 +247,7 @@
    "metadata": {},
    "source": [
     "# Domain geometry, boundary conditions, initial conditions, and stopping condition\n",
-    "The domain geometry is a rectangle that spans [0, 1] in $x$ and [0, 0.5] in $y$. This elongated domain was chosen to allow multiple peaks and valleys in $\\eta_{sol}$ without stretching the interface too much in the $y$ direction (which causes the thickness of the interface to change) or having large regions where $\\eta_{sol}$  never deviates from 0 or 1. Periodic boundary conditions are applied along the $x = 0$ and the $x = 1$ boundaries to accomodate the periodicity of $\\alpha(x,t)$. Dirichlet boundary conditions of $\\eta$ = 0 and $\\eta$ = 1 are applied along the $y = 0$ and the $y = 0.5$ boundaries, respectively. These boundary conditions are chosen to be consistent with $\\eta_{sol}(x,y,t)$. The initial condition is the manufactured solution at $t = 0$:\n",
+    "The domain geometry is a rectangle that spans [0, 1] in $x$ and [0, 0.5] in $y$. This elongated domain was chosen to allow multiple peaks and valleys in $\\eta_{sol}$ without stretching the interface too much in the $y$ direction (which causes the thickness of the interface to change) or having large regions where $\\eta_{sol}$  never deviates from 0 or 1. Periodic boundary conditions are applied along the $x = 0$ and the $x = 1$ boundaries to accomodate the periodicity of $\\alpha(x,t)$. Dirichlet boundary conditions of $\\eta$ = 1 and $\\eta$ = 0 are applied along the $y = 0$ and the $y = 0.5$ boundaries, respectively. These boundary conditions are chosen to be consistent with $\\eta_{sol}(x,y,t)$. The initial condition is the manufactured solution at $t = 0$:\n",
     "\n",
     "$$\n",
     "\\begin{equation}\n",
@@ -269,10 +269,10 @@
     "|-----------|-------|\n",
     "| $\\kappa$  | 0.0004|\n",
     "| $A_1$     | 0.0075|\n",
-    "| $B_1$     | 8.0  |\n",
+    "| $B_1$     | 8.0 $\\pi$  |\n",
     "| $A_2$     | 0.03   |\n",
-    "| $B_2$     | 22.0  |\n",
-    "| $C_2$     | 0.0625|"
+    "| $B_2$     | 22.0 $\\pi$  |\n",
+    "| $C_2$     | 0.0625 $\\pi$|"
    ]
   },
   {
@@ -298,7 +298,7 @@
     "\n",
     "For all of these simulations, verify that the time step is small enough that any temporal error is much smaller that the total error. This can be accomplished by decreasing the time step until it has minimal effect on the error. Ensure that at least three simulation results have $L_2$ errors in the range $[5\\times10^{-3}, 1\\times10^{-4}]$, attempting to cover as much of that range as possible/practical. This maximum and minimum errors in the range roughly represent a poorly resolved simulation and a very well-resolved simulation.\n",
     "\n",
-    "For at least three simulations that have $L_2$ errors in the range $[5\\times10^{-3}, 1\\times10^{-4}]$, save the effective mesh size and $L_2$ error in a CSV or JSON file. Upload this file to the PFHub website as a 2D data set with the effective mesh size as the x-axis column and the $L_2$ error as the y-axis column. Calculate the effective element size as the square root of the area of the finest part of the mesh for nonuniform meshes. For irregular meshes with continous distributions of element sizes, approximate the effective mesh size as the average of the square root of the area of the smallest 5% of the elements.\n",
+    "For at least three simulations that have $L_2$ errors in the range $[5\\times10^{-3}, 1\\times10^{-4}]$, save the effective mesh size and $L_2$ error in a CSV or JSON file. [Upload this file to the PFHub website](https://pages.nist.gov/pfhub/simulations/upload_form/) as a 2D data set with the effective mesh size as the x-axis column and the $L_2$ error as the y-axis column. Calculate the effective element size as the square root of the area of the finest part of the mesh for nonuniform meshes. For irregular meshes with continous distributions of element sizes, approximate the effective mesh size as the average of the square root of the area of the smallest 5% of the elements.\n",
     "\n",
     "Next, confirm that the observed order of accuracy is approximately equal to the expected value. Calculate the order of accuracy, $p$, with a least squares fit of the following function:\n",
     "\n",
@@ -1141,7 +1141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/benchmarks/benchmark7.ipynb
+++ b/benchmarks/benchmark7.ipynb
@@ -269,10 +269,10 @@
     "|-----------|-------|\n",
     "| $\\kappa$  | 0.0004|\n",
     "| $A_1$     | 0.0075|\n",
-    "| $B_1$     | 8.0 $\\pi$  |\n",
+    "| $B_1$     | $8.0 \\pi$  |\n",
     "| $A_2$     | 0.03   |\n",
-    "| $B_2$     | 22.0 $\\pi$  |\n",
-    "| $C_2$     | 0.0625 $\\pi$|"
+    "| $B_2$     | $22.0 \\pi$  |\n",
+    "| $C_2$     | $0.0625 \\pi$|"
    ]
   },
   {
@@ -298,7 +298,14 @@
     "\n",
     "For all of these simulations, verify that the time step is small enough that any temporal error is much smaller that the total error. This can be accomplished by decreasing the time step until it has minimal effect on the error. Ensure that at least three simulation results have $L_2$ errors in the range $[5\\times10^{-3}, 1\\times10^{-4}]$, attempting to cover as much of that range as possible/practical. This maximum and minimum errors in the range roughly represent a poorly resolved simulation and a very well-resolved simulation.\n",
     "\n",
-    "For at least three simulations that have $L_2$ errors in the range $[5\\times10^{-3}, 1\\times10^{-4}]$, save the effective mesh size and $L_2$ error in a CSV or JSON file. [Upload this file to the PFHub website](https://pages.nist.gov/pfhub/simulations/upload_form/) as a 2D data set with the effective mesh size as the x-axis column and the $L_2$ error as the y-axis column. Calculate the effective element size as the square root of the area of the finest part of the mesh for nonuniform meshes. For irregular meshes with continous distributions of element sizes, approximate the effective mesh size as the average of the square root of the area of the smallest 5% of the elements.\n",
+    "Save the effective element size, $h$, and the $L_2$ error for each simulation.\n",
+    "[Archive this data](https://github.com/usnistgov/pfhub/issues/491) in a\n",
+    "CSV or JSON file, using one column (or key) each for $h$ and $L_2$. \n",
+    "Calculate the effective element size as the square root of the area of\n",
+    "the finest part of the mesh for nonuniform meshes. For irregular meshes\n",
+    "with continuous distributions of element sizes, approximate the effective\n",
+    "element size as the average of the square root of the area of the smallest\n",
+    "5% of the elements. Then [submit your results on the PFHub website](https://pages.nist.gov/pfhub/simulations/upload_form/) as a 2D data set with the effective mesh size as the x-axis column and the $L_2$ error as the y-axis column.\n",
     "\n",
     "Next, confirm that the observed order of accuracy is approximately equal to the expected value. Calculate the order of accuracy, $p$, with a least squares fit of the following function:\n",
     "\n",
@@ -308,7 +315,7 @@
     "\n",
     "where $E$ is the $L_2$ error, $R$ is the effective element size, and b is an intercept. Deviations of ±0.2 or more from the theoretical value are to be expected (depending on the range of errors considered and other factors).\n",
     "\n",
-    "Finally, perform a similar convergence test, but for the time step, systematically changing the time step and recording the $L_2$ error. Use a time step that does not vary over the course of any single simulation. Verify that the spatial discretization error is small enough that it does not substantially contribute to the total error. Once again, ensure that at least three simulations have $L_2$ errors in the range $[5\\times10^{-3}, 1\\times10^{-4}]$, attempting to cover as much of that range as possible/practical. Save the effective mesh size and $L_2$ error for each individual simulation in a CSV or JSON file. [Upload this file to the PFHub website](https://pages.nist.gov/pfhub/simulations/upload_form/) as a 2D data set with the time step size as the x-axis column and the $L_2$ error as the y-axis column. Confirm that the observed order of accuracy is approximately equal to the expected value."
+    "Finally, perform a similar convergence test, but for the time step, systematically changing the time step and recording the $L_2$ error. Use a time step that does not vary over the course of any single simulation. Verify that the spatial discretization error is small enough that it does not substantially contribute to the total error. Once again, ensure that at least three simulations have $L_2$ errors in the range $[5\\times10^{-3}, 1\\times10^{-4}]$, attempting to cover as much of that range as possible/practical. [Archive the effective mesh size and $L_2$ error](https://github.com/usnistgov/pfhub/issues/491) for each individual simulation in a CSV or JSON file. [Submit your results to the PFHub website](https://pages.nist.gov/pfhub/simulations/upload_form/) as a 2D data set with the time step size as the x-axis column and the $L_2$ error as the y-axis column. Confirm that the observed order of accuracy is approximately equal to the expected value."
    ]
   },
   {
@@ -318,7 +325,8 @@
     "## Part (b)\n",
     "Now that your code has been verified in (a), the objective of this part is to determine the computational performance of your code at various levels of error. These results can then be used to objectively compare the performance between codes or settings within the same code. To make the problem more computationally demanding and stress solvers more than in (a), decrease $\\kappa$ by a factor of $256$ to $1.5625\\times10^{-6}$. This change will reduce the interfacial thickness by a factor of $16$.\n",
     "\n",
-    "Run a series of simulations, attempting to optimize solver parameters (mesh, time step, tolerances, etc.) to minimize the required computational resources for at least three levels of $L_2$ error in range  $[5\\times10^{-3}, 1\\times10^{-5}]$. Use the same CPU and processor type for all simulations. For the best of these simulations, save the wall time (in seconds), number of computing cores, normalized computing cost (wall time in seconds $\\times$ number of cores $\\times$ nominal core speed $/$ 2 GHz), maximum memory usage, and $L_2$ error at $t=8$ for each individual simulation in a CSV or JSON file. [Upload this to the PFHub website](https://pages.nist.gov/pfhub/simulations/upload_form/) as two 2D data sets. For the first data set use the $L_2$ error as the x-axis column and the normalized computational cost as the the y-axis column. For the second data set,  use the $L_2$ error as the x-axis column and the wall time as the the y-axis column."
+    "Run a series of simulations, attempting to optimize solver parameters (mesh, time step, tolerances, etc.) to minimize the required computational resources for at least three levels of $L_2$ error in range  $[5\\times10^{-3}, 1\\times10^{-5}]$. Use the same CPU and processor type for all simulations. For the best of these simulations, save the wall time (in seconds), number of computing cores, normalized computing cost (wall time in seconds $\\times$ number of cores $\\times$ nominal core speed $/$ 2 GHz), maximum memory usage, and $L_2$ error at $t=8$ for each individual simulation.  [Archive this data](https://github.com/usnistgov/pfhub/issues/491) in a\n",
+    "CSV or JSON file with one column (or key) for each of the quantities mentioned above. [Submit your results to the PFHub website](https://pages.nist.gov/pfhub/simulations/upload_form/) as two 2D data sets. For the first data set use the $L_2$ error as the x-axis column and the normalized computational cost as the the y-axis column. For the second data set,  use the $L_2$ error as the x-axis column and the wall time as the the y-axis column."
    ]
   },
   {
@@ -1141,7 +1149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes two errors in BM7 that were noticed by Damien.

Fixes swapped Dirichlet boundary conditions and missing factors of pi for parameters B1, B2, and C2. Also added a missing link to the upload form.

Go to, http://random-cat-741.surge.sh/benchmarks/benchmark7.ipynb/ to review

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-741.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/741)
<!-- Reviewable:end -->
