### PR TITLE
Fix missing table in vega comparison pages

### DIFF
--- a/_data/hexbin.py
+++ b/_data/hexbin.py
@@ -18,9 +18,9 @@ def check_status(datum):
     """Check that both the url and image link are valid URLs and that the
     image link isn't just a redirect.
     """
-    if requests.get(datum['url']).status_code != 200:
+    if requests.get(datum['url'], verify=False).status_code != 200:
         return False
-    get_ = requests.get(datum['image'])
+    get_ = requests.get(datum['image'], verify=False)
     if get_.status_code != 200:
         return False
     if get_.url != datum['image']:

--- a/_includes/simulations.html
+++ b/_includes/simulations.html
@@ -76,7 +76,7 @@
 </div>
 
 
-<script> var benchmark_id="{{ include.benchmark_id }}" </script>
+<script> var BENCHMARK_ID="{{ include.benchmark_id }}" </script>
 <script src="{{ site.baseurl }}/js/data_table.js"></script>
 
 {% include ribbon.html %}


### PR DESCRIPTION
Make the benchmark table appear on landing pages with Vega. This had
gone missing in an earlier change.

The tables are missing on some comparison pages on the main site. See,

https://pages.nist.gov/pfhub/simulations/1a.1/

and are now present

http://random-cat-768.surge.sh//simulations/1a.1/

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-768.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/768)
<!-- Reviewable:end -->
