### PR TITLE
fix PRISMS-PF 7b meta.yaml

### DIFF
--- a/_data/simulations/PRISMSPF_Quad_7b/meta.yaml
+++ b/_data/simulations/PRISMSPF_Quad_7b/meta.yaml
@@ -37,7 +37,7 @@ data:
       - unit: KB
         value: '0'
   - name: cost
-    url: 'https://f000.backblazeb2.com/file/pfhub-sjd/bm7a_linear.csv'
+    url: 'https://f000.backblazeb2.com/file/pfhub-sjd/bm7b_quad.csv'
     format:
       type: csv
       parse:
@@ -53,17 +53,17 @@ data:
         expr: datum.cost
         as: 'y'
   - name: time
-    url: 'https://f000.backblazeb2.com/file/pfhub-sjd/bm7a_linear.csv'
+    url: 'https://f000.backblazeb2.com/file/pfhub-sjd/bm7b_quad.csv'
     format:
       type: csv
       parse:
-        erro: number
+        error: number
         wall_time: number
     description: Error vs Time plot
     type: line
     transform:
       - type: formula
-        expr: datum.erro
+        expr: datum.error
         as: x
       - type: formula
         expr: datum.wall_time


### PR DESCRIPTION
Fixes the problems with the meta.yaml file for the PRISMS-PF 7b simulation in #765 

Links to issues such as "Fixes #XXX" or "Addresses #XXX".

A longer description and justification for the changes.

Raise any areas of concern.



<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-{pull-request-number}.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/771)
<!-- Reviewable:end -->
