### PR TITLE
Switch order of Mathjax loading

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -54,24 +54,6 @@
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <link type="text/css" rel="stylesheet" href="{{ site.baseurl }}/css/materialize.min.css"  media="screen"/>
 
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    extensions: ["tex2jax.js"],
-    jax: ["input/TeX", "output/HTML-CSS"],
-    tex2jax: {
-      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-      processEscapes: true
-    },
-    "HTML-CSS": { availableFonts: ["TeX"] }
-  });
-</script>
-
-<script type="text/javascript"
-        async
-        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-</script>
-
 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 
 <style>
@@ -115,4 +97,22 @@
   ga('create', 'UA-88929635-1', 'auto');
   ga('send', 'pageview');
 
+</script>
+
+<script type="text/x-mathjax-config">
+  MathJax.Hub.Config({
+    <!-- extensions: ["tex2jax.js"], -->
+    jax: ["input/TeX", "output/HTML-CSS"],
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+      processEscapes: true
+    },
+    "HTML-CSS": { availableFonts: ["TeX"] }
+  });
+</script>
+
+<script type="text/javascript"
+        async
+        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.3/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>


### PR DESCRIPTION
Address #788

Make Mathjax load last in head.html. It might be that Plotly also uses
some version of Mathjax, which could cause some corruption. Testing on
localhost seems to show that Chrome renders the tex when the order is
switched. This is an intermittent problem so it's not always clear if
the changes make a difference.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-789.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/789)
<!-- Reviewable:end -->
