### PR TITLE
Remove MIT License badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ alt="Gitter Chat">
 <img src="https://api.travis-ci.org/usnistgov/pfhub.svg"
 alt="Travis CI">
 </a>
-<a href="https://github.com/usnistgov/pfhub/blob/nist-pages/LICENSE.md">
-<img src="https://img.shields.io/badge/license-mit-blue.svg" alt="License" height="18">
-</a>
 </p>
 
 ## Overview

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
         <a class="grey-text text-lighten-4 right"
            target="_blank"
            href="{{ site.links.license }}">
-          MIT License
+          NIST License
         </a>
       </div>
     </div>


### PR DESCRIPTION
**PFHub is public domain.**

Closes #790.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-791.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/791)
<!-- Reviewable:end -->
