### PR TITLE
Major bug fixes

### DIFF
--- a/_data/simulations/CHiMaD3_MOOSE/meta.yaml
+++ b/_data/simulations/CHiMaD3_MOOSE/meta.yaml
@@ -7,12 +7,12 @@ metadata:
     github_id: eastglow-zz
   timestamp: '27 June, 2018'
   summary: >-
-    960x960 dendritic growth simulation was performed with MOOSE-framework
+    MOOSE framework; mesh adaptivity, bdf2 time stepping with adaptive time steps (dtmax = 0.3), postprocesses on the every timestep
   implementation:
     name: MOOSE-framework
     repo:
       url: 'https://github.com/eastglow-zz/CHiMaD3_dendritic_growth'
-      version: 1f18606
+      version: 5e05167
     container_url: ''
   hardware:
     cpu_architecture: x86_64
@@ -27,7 +27,7 @@ benchmark:
 data:
   - name: run_time
     values:
-      - wall_time: '50121'
+      - wall_time: '108381'
         sim_time: '1500'
   - name: memory_usage
     values:
@@ -35,7 +35,7 @@ data:
         value: '7022900'
   - name: efficiency
     values:
-      - time_ratio: 0.02992
+      - time_ratio: 0.01384
         memory: 7022900.0
     transform:
       - type: formula
@@ -46,7 +46,7 @@ data:
         as: 'y'
   - name: free_energy
     url: >-
-      https://gist.githubusercontent.com/eastglow-zz/56944749f48c7a8b03af43c30312a509/raw/ce369a3bb0a8fe79f159b9e05c99af17cb68342e/CHiMaD3_DK_Tot_FE.csv
+      https://gist.githubusercontent.com/eastglow-zz/62ca8baba6e66bfb07ceb96bf65206aa/raw/5310ddf815512eb7824c3612ab63c998649c9b44/CHiMaD3_DK_w_postprocess_out.csv
     format:
       type: csv
       parse:
@@ -63,7 +63,7 @@ data:
         as: 'y'
   - name: solid_fraction
     url: >-
-      https://gist.githubusercontent.com/eastglow-zz/62ca8baba6e66bfb07ceb96bf65206aa/raw/6918c8321a0c3f96f684b63710b42cc2fb2707b3/CHiMaD3_DK_w_postprocess_out.csv
+      https://gist.githubusercontent.com/eastglow-zz/62ca8baba6e66bfb07ceb96bf65206aa/raw/5310ddf815512eb7824c3612ab63c998649c9b44/CHiMaD3_DK_w_postprocess_out.csv
     format:
       type: csv
       parse:
@@ -80,7 +80,7 @@ data:
         as: 'y'
   - name: tip_position
     url: >-
-      https://gist.githubusercontent.com/eastglow-zz/62ca8baba6e66bfb07ceb96bf65206aa/raw/6918c8321a0c3f96f684b63710b42cc2fb2707b3/CHiMaD3_DK_w_postprocess_out.csv
+      https://gist.githubusercontent.com/eastglow-zz/62ca8baba6e66bfb07ceb96bf65206aa/raw/5310ddf815512eb7824c3612ab63c998649c9b44/CHiMaD3_DK_w_postprocess_out.csv
     format:
       type: csv
       parse:
@@ -97,7 +97,7 @@ data:
         as: 'y'
   - name: phase_field_1500
     url: >-
-      https://gist.githubusercontent.com/eastglow-zz/96ca7c17913a9d0a9bfbd0405341f31a/raw/3c1bba7f03ac4164967e99f30e24c1b4908332fd/phase_field_1500.csv
+      https://gist.githubusercontent.com/eastglow-zz/96ca7c17913a9d0a9bfbd0405341f31a/raw/353b8af9f77f7ef36e64853e6a66c119e26c5361/phase_field_1500.csv
     format:
       type: csv
       parse:

--- a/_data/simulations/CHiMaD3_MOOSE/meta.yaml
+++ b/_data/simulations/CHiMaD3_MOOSE/meta.yaml
@@ -12,7 +12,7 @@ metadata:
     name: MOOSE-framework
     repo:
       url: 'https://github.com/eastglow-zz/CHiMaD3_dendritic_growth'
-      version: 5e05167
+      version: 78a47b4
     container_url: ''
   hardware:
     cpu_architecture: x86_64


### PR DESCRIPTION
-Typo in the anisotropy function was corrected.
-Initial dt and maximum dt were set as 0.003 and 0.3 respectively, as stated in the paper (A.M. Jokisaari et al, Phase field benchmark problems for dendritic growth and linear elasticity, Computational Materials Science, 149 (2013) 336).



<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-{pull-request-number}.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/796)
<!-- Reviewable:end -->
