### PR TITLE
Update Travis CI to cache results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ after_success:
   - export SURGE_LOGIN="daniel.wheeler@nist.gov"
   - export SURGE_TOKEN="3712d1678fabe65dfad576545befce2f"
   - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-      nix-shell --pure --command "surge --project _site --domain ${DOMAIN}";
+      nix-shell --command "surge --project _site --domain ${DOMAIN}";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_cache:
   - mkdir -p $STORE
   - nix copy --to file://$STORE -f shell.nix buildInputs
 install:
-  - nix-build shell.nix -A buildInputs
+  - nix-env -if shell.nix
 script:
   - nix-shell --pure --command "pylint _data/*.py"
   - nix-shell --pure --command "flake8 _data/*.py"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,42 @@
 ---
 language: nix
+env:
+  global:
+    - STORE=$HOME/nix-store
+cache:
+  directories:
+    - $STORE
+before_install:
+  - sudo mkdir -p /etc/nix
+  - echo "binary-caches = https://cache.nixos.org/ file://$STORE" | sudo tee -a /etc/nix/nix.conf > /dev/null
+  - echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
+before_cache:
+  - mkdir -p $STORE
+  - nix copy --to file://$STORE -f shell.nix buildInputs
+install:
+  - nix-build shell.nix -A buildInputs
 script:
-  - nix-shell --run "pylint _data/*.py"
-  - nix-shell --run "flake8 _data/*.py"
-  - nix-shell --run "make simulations"
-  - nix-shell --run 'find . -name "*.ipynb" -type f -not -path "*/.ipynb_checkpoints/*" -exec touch {} \;'
-  - nix-shell --run "make notebooks"
-  - nix-shell --run "touch _data/hexbin.yaml"
-  - nix-shell --run "make hexbin"
-  - nix-shell --run "rm -rf ./_site"
-  - nix-shell --run "jekyll build -d ./_site/pfhub && htmlproofer --check-html --only-4xx --allow-hash-href --empty-alt-ignore --checks-to-ignore ImageCheck --file-ignore ./_site/pfhub/node_modules ./_site"
-  - nix-shell --run "py.test --ignore=hackathons/hackathon1 --ignore=benchmarks --ignore=_data --nbval --sanitize-with sanitize.cfg"
-  - nix-shell --run "coffeelint _includes/coffee/"
-  - nix-shell --run "mocha _site/pfhub/js/test.js"
+  - nix-shell --pure --command "pylint _data/*.py"
+  - nix-shell --pure --command "flake8 _data/*.py"
+  - nix-shell --pure --command "make simulations"
+  - nix-shell --pure --command 'find . -name "*.ipynb" -type f -not -path "*/.ipynb_checkpoints/*" -exec touch {} \;'
+  - nix-shell --pure --command "make notebooks"
+  - nix-shell --pure --command "touch _data/hexbin.yaml"
+  - nix-shell --pure --command "make hexbin"
+  - nix-shell --pure --command "rm -rf ./_site"
+  - nix-shell --pure --command "jekyll build -d ./_site/pfhub && htmlproofer --check-html --only-4xx --allow-hash-href --empty-alt-ignore --checks-to-ignore ImageCheck --file-ignore ./_site/pfhub/node_modules ./_site"
+  - nix-shell --pure --command "py.test --ignore=hackathons/hackathon1 --ignore=benchmarks --ignore=_data --nbval --sanitize-with sanitize.cfg"
+  - nix-shell --pure --command "coffeelint _includes/coffee/"
+  - nix-shell --pure --command "mocha _site/pfhub/js/test.js"
 after_success:
-  - nix-shell --run "rm -rf ./_site"
-  - nix-shell --run "make simulations"
-  - nix-shell --run "make notebooks"
-  - nix-shell --run "make hexbin"
-  - nix-shell --run "jekyll build --baseurl ''"
+  - nix-shell --pure --command "rm -rf ./_site"
+  - nix-shell --pure --command "make simulations"
+  - nix-shell --pure --command "make notebooks"
+  - nix-shell --pure --command "make hexbin"
+  - nix-shell --pure --command "jekyll build --baseurl ''"
   - export DOMAIN=random-cat-${TRAVIS_PULL_REQUEST}.surge.sh
   - export SURGE_LOGIN="daniel.wheeler@nist.gov"
   - export SURGE_TOKEN="3712d1678fabe65dfad576545befce2f"
   - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-      nix-shell --run "surge --project _site --domain ${DOMAIN}";
+      nix-shell --pure --command "surge --project _site --domain ${DOMAIN}";
     fi

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,6 @@ hexbin: $(HEXBIN_OUT)
 notebooks: $(NOTEBOOKS_HTML) $(NOTEBOOKS_MD)
 
 print-%  : ; @echo $* = $($*)
+
+install:
+	echo "fake install"

--- a/_nix/env.nix
+++ b/_nix/env.nix
@@ -3,4 +3,5 @@ nixpkgs.stdenv.mkDerivation rec {
   name = "pfhub";
   env = nixpkgs.buildEnv { name=name; paths=buildInputs; };
   buildInputs = ( import ./build.nix { inherit nixpkgs; }) ++ extra;
+  src = ./..;
 }


### PR DESCRIPTION
Fixes #798 

Use Travis CI's caching facility to cache the Nix build. Tests now run in 10 min 15 sec which is noticeably less than previous tests.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-799.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/799)
<!-- Reviewable:end -->
