### PR TITLE
Hardwire locale into nix-shell when running black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 script:
   - nix-shell --pure --command "pylint _data/*.py"
   - nix-shell --pure --command "flake8 _data/*.py"
-  - nix-shell --pure --command "black --check _data/*.py"
+  - nix-shell --pure --command "LC_ALL=en_US.UTF-8 black --check _data/*.py"
   - nix-shell --pure --command "make simulations"
   - nix-shell --pure --command 'find . -name "*.ipynb" -type f -not -path "*/.ipynb_checkpoints/*" -exec touch {} \;'
   - nix-shell --pure --command "make notebooks"


### PR DESCRIPTION
Address #822 

Ensure that the locale is set when running black linter from nix-shell. All locale variables are unset by nix-shell in pure mode.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-823.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/823)
<!-- Reviewable:end -->
