### PR TITLE
Don't post comment for curl failure

### DIFF
--- a/_code/comment.sh
+++ b/_code/comment.sh
@@ -17,12 +17,6 @@ function pull_request_url {
     echo "https://api.github.com/repos/${TRAVIS_PULL_REQUEST_SLUG}/issues/${TRAVIS_PULL_REQUEST}";
 }
 
-# Get the name of the simulation from the pull request title which is
-# always something like "PFHub Upload: fipy_1a_travis". This function
-# is only run once.
-function sim_name {
-    echo `curl -X GET "$( pull_request_url )" | jq -r '.title' | sed -e 's/PFHub Upload: //'`
-}
 
 # Get the base path to the meta.yaml given the simulation name
 function yaml_path {
@@ -74,13 +68,22 @@ function comment {
 
 # Post the comment to GitHub given the simulation name
 function post_comment {
-    curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d "{\"body\": \"$( comment $( sim_name ) )\"}" "$( pull_request_url )/comments"
+    curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST -d "{\"body\": \"$( comment $1 )\"}" "$( pull_request_url )/comments"
 }
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
     if is_staticman_branch
     then
-        post_comment
+        HTTP_RESPONSE=$(curl -X GET "$( pull_request_url )" --silent --write-out "HTTPSTATUS:%{http_code}")
+        HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
+        HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+        if [ $HTTP_STATUS = "200" ]
+        then
+            SIM_NAME=`echo "${HTTP_BODY}" | jq -r '.title' | sed -e 's/PFHub Upload: //'`
+            post_comment "$SIM_NAME"
+        else
+            echo "HTTP_RESPONSE: ${HTTP_RESPONSE}"
+        fi
     fi
 fi


### PR DESCRIPTION
Only post the pull request comment on a 200 return from the curl
command. Sometimes the message posts with an empty github ID
intermittently. The script needs to know the name of the simulation in
order to extract the github ID. If curl fails then it cannot do
so. This is partly a debugging step so we can see the return status
when failures occur.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-{pull-request-number}.surge.sh
