### PR TITLE
Use Surge upload form to amend upload data

### DIFF
--- a/_code/comment.sh
+++ b/_code/comment.sh
@@ -54,7 +54,7 @@ function github_id {
 # Get the link to edit the meta.yaml on GitHub given the simulation
 # name. This will fork the repository to the user's area.
 function edit_link {
-    echo "https://github.com/${TRAVIS_PULL_REQUEST_SLUG}/edit/${TRAVIS_PULL_REQUEST_BRANCH}/$( yaml_path $1 )?pr=%2Fusnistgov%2Fpfhub%2Fpull%2F${TRAVIS_PULL_REQUEST}"
+    echo "https://${DOMAIN}/simulations/upload_form/?sim=$1"
 }
 
 # The link to the individual landing page given the simulation name
@@ -69,7 +69,7 @@ function link2 {
 
 # Get the comment to post given the simulation name
 function comment {
-    echo "@$( github_id $1 ), thanks for your PFHub upload! Your upload appears to have passed the tests.\n\nYou can view your upload display at\n\n - $( link1 $1 )\n\nand\n\n - $( link2 $1 )\n\nPlease review and confirm your approval to @wd15 by commenting in this pull request.\n\nYou can make further changes to this pull request by [editing the meta.yaml]($( edit_link $1 )) associated with this pull request.";
+    echo "@$( github_id $1 ), thanks for your PFHub upload! Your upload appears to have passed the tests.\n\nYou can view your upload display at\n\n - $( link1 $1 )\n\nand\n\n - $( link2 $1 )\n\nPlease review and confirm your approval to @wd15 by commenting in this pull request.\n\nIf you think there is a mistake in your uploade data, then you can resubmit the upload [at this link]($( edit_link $1 )).";
 }
 
 # Post the comment to GitHub given the simulation name

--- a/_code/comment.sh
+++ b/_code/comment.sh
@@ -69,7 +69,7 @@ function link2 {
 
 # Get the comment to post given the simulation name
 function comment {
-    echo "@$( github_id $1 ), thanks for your PFHub upload! Your upload appears to have passed the tests.\n\nYou can view your upload display at\n\n - $( link1 $1 )\n\nand\n\n - $( link2 $1 )\n\nPlease review and confirm your approval to @wd15 by commenting in this pull request.\n\nIf you think there is a mistake in your uploade data, then you can resubmit the upload [at this link]($( edit_link $1 )).";
+    echo "@$( github_id $1 ), thanks for your PFHub upload! Your upload appears to have passed the tests.\n\nYou can view your upload display at\n\n - $( link1 $1 )\n\nand\n\n - $( link2 $1 )\n\nPlease review and confirm your approval to @wd15 by commenting in this pull request.\n\nIf you think there is a mistake in your upload data, then you can resubmit the upload [at this link]($( edit_link $1 )).";
 }
 
 # Post the comment to GitHub given the simulation name


### PR DESCRIPTION
Instead of pointing to the meta.yaml to make amends to the pull
request data, just use the upload form on Surge. Much easier for users
that are unfamiliar with GitHub or the meta.yaml format.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-857.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/857)
<!-- Reviewable:end -->
