### PR TITLE
Auto-convert github url to raw.githubusercontent

### DIFF
--- a/_includes/coffee/main.coffee
+++ b/_includes/coffee/main.coffee
@@ -86,15 +86,20 @@ github_to_raw = (data) ->
   ### Convert a GitHub URL to raw format
 
   Args:
-    data: the GitHub URL
+    data: URL of renderable data on github.com
 
   Returns:
-    the updated url
+    URL of raw/downloadable data on githubuserdata.com
   ###
   pattern = ->
     ///
-    https:\/\/github\.com\/([A-Za-z0-9_-]{3,15})\/([A-Za-z0-9_.-]+)\/blob\/(.+)$
-    ///
+    https?:\/\/              # https or http
+    (?:www\.)?github\.com\/  # www.github.com, www optional
+    ([a-z0-9_-]{3,39})\/     # capture user name / org
+    ([a-z0-9_.-]+)\/         # capture repository
+    blob\/
+    (.+)                     # capture path
+    $///i                    # case insensitive
 
   sequence(
     (x) -> pattern().exec(x)

--- a/_includes/coffee/main.coffee
+++ b/_includes/coffee/main.coffee
@@ -81,3 +81,26 @@ link_html = (link, data) ->
   #{data}
   </a>
   """
+
+github_to_raw = (data) ->
+  ### Convert a GitHub URL to raw format
+
+  Args:
+    data: the GitHub URL
+
+  Returns:
+    the updated url
+  ###
+  pattern = ->
+    ///
+    https:\/\/github\.com\/([A-Za-z0-9_-]{3,15})\/([A-Za-z0-9_.-]+)\/blob\/(.+)$
+    ///
+
+  sequence(
+    (x) -> pattern().exec(x)
+    (x) ->
+      if x?
+        "https://raw.githubusercontent.com/#{x[1]}/#{x[2]}/#{x[3]}"
+      else
+        data
+  )(data)

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -329,6 +329,30 @@ describe('test map_undef', ->
 )
 
 
+describe('test github_to_raw', ->
+  it('with github.com address', ->
+    slug = ->
+      'jah5759/benchmark_results'
+    path = ->
+      '1_spinodal_decomp/1a_square_periodic/1a_square_periodic_out.csv'
+    assert.deepEqual(
+      github_to_raw(
+        "https://github.com/#{slug()}/blob/benchmark_results/#{path()}"
+      )
+      "https://raw.githubusercontent.com/#{slug()}/benchmark_results/#{path()}"
+    )
+  )
+  it('without github.com address', ->
+    assert.deepEqual(
+      github_to_raw(
+        'https://bitly.com/'
+      )
+      'https://bitly.com/'
+    )
+  )
+)
+
+
 # describe('result_comparison functions', ->
 #   data = ->
 #     [

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -328,18 +328,21 @@ describe('test map_undef', ->
   )
 )
 
-
 describe('test github_to_raw', ->
+  slug = ->
+    'jah5759/benchmark_results'
+  path = ->
+    '1_spinodal_decomp/1a_square_periodic/1a_square_periodic_out.csv'
+  slug_long = ->
+    'longusernamelongusername/benchmark_results'
+  raw_base = ->
+    'https://raw.githubusercontent.com'
   it('with github.com address', ->
-    slug = ->
-      'jah5759/benchmark_results'
-    path = ->
-      '1_spinodal_decomp/1a_square_periodic/1a_square_periodic_out.csv'
     assert.deepEqual(
       github_to_raw(
         "https://github.com/#{slug()}/blob/benchmark_results/#{path()}"
       )
-      "https://raw.githubusercontent.com/#{slug()}/benchmark_results/#{path()}"
+      "#{raw_base()}/#{slug()}/benchmark_results/#{path()}"
     )
   )
   it('without github.com address', ->
@@ -348,6 +351,30 @@ describe('test github_to_raw', ->
         'https://bitly.com/'
       )
       'https://bitly.com/'
+    )
+  )
+  it('with GitHub.com address', ->
+    assert.deepEqual(
+      github_to_raw(
+        "https://GitHub.com/#{slug()}/blob/benchmark_results/#{path()}"
+      )
+      "#{raw_base()}/#{slug()}/benchmark_results/#{path()}"
+    )
+  )
+  it('with www.github.com address', ->
+    assert.deepEqual(
+      github_to_raw(
+        "https://www.github.com/#{slug()}/blob/benchmark_results/#{path()}"
+      )
+      "#{raw_base()}/#{slug()}/benchmark_results/#{path()}"
+    )
+  )
+  it('with long user name', ->
+    assert.deepEqual(
+      github_to_raw(
+        "https://www.github.com/#{slug_long()}/blob/benchmark_results/#{path()}"
+      )
+      "#{raw_base()}/#{slug_long()}/benchmark_results/#{path()}"
     )
   )
 )

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -377,6 +377,14 @@ describe('test github_to_raw', ->
       "#{raw_base()}/#{slug_long()}/benchmark_results/#{path()}"
     )
   )
+  it('with http not https', ->
+    assert.deepEqual(
+      github_to_raw(
+        "http://github.com/#{slug()}/blob/benchmark_results/#{path()}"
+      )
+      "#{raw_base()}/#{slug()}/benchmark_results/#{path()}"
+    )
+  )
 )
 
 

--- a/_includes/data_input.html
+++ b/_includes/data_input.html
@@ -29,7 +29,7 @@
   <div class="input-field col s12 m5 l5 xl5">
     <a class="tooltipped prefix"
        data-position="bottom"
-       data-tooltip="URL for the raw data file either in JSON or CSV format (required).">
+       data-tooltip="URL for the raw data file either in JSON or CSV format (required)">
       <i class="material-icons">help</i>
     </a>
     <input required

--- a/_includes/data_input.html
+++ b/_includes/data_input.html
@@ -22,21 +22,22 @@
            class="validate"
            length="64"
            pattern="^[\\w]{2,64}$">
-    <label for="data-name-{{ counter }}">
+    <label for="data-name-{{ counter }}" data-error="alphanumeric characters and _ (at least 2 characters long)">
       Short name of data
     </label>
   </div>
   <div class="input-field col s12 m5 l5 xl5">
     <a class="tooltipped prefix"
        data-position="bottom"
-       data-tooltip="URL for the raw data file either in JSON or CSV format (required)">
+       data-tooltip="URL for the raw data file either in JSON or CSV format (required).">
       <i class="material-icons">help</i>
     </a>
     <input required
            id="data-url-{{ counter }}"
            name="fields[data][{{ counter }}][url]"
            type="url"
-           class="validate">
+           class="validate"
+           onchange="update_url(this)">
     <label for="data-url-{{ counter }}">
       Data File URL
     </label>

--- a/js/upload_form.coffee
+++ b/js/upload_form.coffee
@@ -2,6 +2,7 @@
 ---
 
 {% include coffee/essential.coffee %}
+{% include coffee/main.coffee %}
 
 mapping = (data, sim_name) ->
   {
@@ -210,3 +211,6 @@ if SIM_NAME?
   $('#par_' + DATA.metadata.hardware.parallel_model).attr('selected', '')
   populate_data_section(DATA)
   populate_media_section(DATA)
+
+@update_url = (data) ->
+  data.value = github_to_raw(data.value)


### PR DESCRIPTION
Address #858

Automatically convert github.com data links to raw.githubusercontent.com links in the [upload form](http://random-cat-861.surge.sh/simulations/upload_form/). Many users do not supply the correct raw links to github data, which leads to a lot of manual editing of the meta.yaml

Test this by copying and pasting a github.com link for a file into the data URL in the [upload form](http://random-cat-861.surge.sh/simulations/upload_form/). It will automatically change to the correct raw.githubusercontent.com link at the onchange event.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-861.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/861)
<!-- Reviewable:end -->
