### PR TITLE
Authorize GET request in auto comment code

### DIFF
--- a/_code/comment.sh
+++ b/_code/comment.sh
@@ -75,7 +75,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]
 then
     if is_staticman_branch
     then
-        HTTP_RESPONSE=$(curl -X GET "$( pull_request_url )" --silent --write-out "HTTPSTATUS:%{http_code}")
+        HTTP_RESPONSE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" -X GET "$( pull_request_url )" --silent --write-out "HTTPSTATUS:%{http_code}")
         HTTP_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')
         HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
         if [ $HTTP_STATUS = "200" ]


### PR DESCRIPTION
Address #864

Authorize the GET request when getting the pull request data from
GitHub on Travis CI to avoid rate limiting issues.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-867.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/867)
<!-- Reviewable:end -->
