### PR TITLE
Remove manual creation of efficiency data

### DIFF
--- a/_data/benchmarks.yaml
+++ b/_data/benchmarks.yaml
@@ -79,6 +79,8 @@
       minimum: 0.01
       type: line
       mode: lines
+      func: get_values
+
     - name: tip_position
       title: Tip Position
       x_title: Time
@@ -87,6 +89,8 @@
       y_scale: linear
       type: line
       mode: lines
+      func: get_values
+
     - name: solid_fraction
       title: Solid Fraction
       y_title: Solid Fraction
@@ -95,6 +99,8 @@
       y_scale: linear
       type: line
       mode: lines
+      func: get_values
+
     - name: phase_field_1500
       type: line
       x_scale: linear
@@ -106,6 +112,8 @@
       y_domain: [0, 500]
       y_scaleanchor: x
       mode: lines
+      func: get_values
+
     - name: efficiency
       type: line
       x_scale: log
@@ -115,6 +123,7 @@
       title: Efficiency
       mode: markers
       footnote: "<span class='plotly-footnote' >* Wall time divided by the total simulated time.</span>"
+      func: get_values
 
 - title: Linear Elasticity
   description: Linear elasticity via evolution of a constrained precipitate


### PR DESCRIPTION
Address #877

No longer require the manual creation of efficiency data generated
from the memory_usage and run_time data. Furthermore, allow
customization of data function that generate the x and y data in
plotly plots.

See http://random-cat-906.surge.sh/simulations/3a.1/ to review
<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-906.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/906)
<!-- Reviewable:end -->
