### PR TITLE
Switch prose.io edit links to use usnistgov

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,8 +34,8 @@ plugins: [jekyll-coffeescript]
 
 admin_email: 'chimad-phase-field-admin@list.nist.gov'
 
-new_edit: 'http://prose.io/#wd15/pfhub/tree/wiki'
-prose_edit: 'http://prose.io/#wd15/pfhub/edit/wiki'
+new_edit: 'http://prose.io/#usnistgov/pfhub/tree/master'
+prose_edit: 'http://prose.io/#usnistgov/pfhub/edit/master'
 github_edit: 'https://github.com/usnistgov/pfhub/edit/master'
 source_edit: 'https://github.com/usnistgov/pfhub/blob/master'
 history_edit: 'https://github.com/usnistgov/pfhub/commits/master'


### PR DESCRIPTION
Address #910

Switch prose.io edit links to use usnistgov/pfhub/master instead of
wd15/pfhub/wiki.

This works for everyone apart from those with write permission to the
pfhub repository. tkphyd, guyer and wd15 will have to edit on their
own forks. Kind of related to this,
https://github.com/prose/prose/issues/685, but it would be nice to set
up the admin users to do a pull request.

The problem is that admin users have write access to usnistgov/pfhub
so prose.io thinks they should be able to write, but usnistgov won't
let prose.io write as it hasn't been authenticated. There is something
messed up in the prose.io logic.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-911.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/911)
<!-- Reviewable:end -->
