### PR TITLE
Fix bug in efficiency plot

### DIFF
--- a/_data/benchmarks.yaml
+++ b/_data/benchmarks.yaml
@@ -123,7 +123,7 @@
       title: Efficiency
       mode: markers
       footnote: "<span class='plotly-footnote' >* Wall time divided by the total simulated time.</span>"
-      func: get_values
+      func: efficiency
 
 - title: Linear Elasticity
   description: Linear elasticity via evolution of a constrained precipitate

--- a/_includes/coffee/result_comparison.coffee
+++ b/_includes/coffee/result_comparison.coffee
@@ -67,8 +67,9 @@ vega_to_plotly = (chart_item, sim_name) ->
 
   efficiency = (name, datum) ->
     if datum is 'x'
-      [get_values('run_time', 'wall_time')[0] /
-       get_values('run_time', 'sim_time')[0]]
+      (x) ->
+        [get_values('run_time', 'wall_time')(x)[0] /
+         get_values('run_time', 'sim_time')(x)[0]]
     else if datum is 'y'
       get_values('memory_usage', 'value')
 


### PR DESCRIPTION
Address #914, #915

Switch the efficiency plot to use the correct data source

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-916.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/916)
<!-- Reviewable:end -->
