### PR TITLE
Issue880 better repo link

### DIFF
--- a/_includes/coffee/simulation.coffee
+++ b/_includes/coffee/simulation.coffee
@@ -242,6 +242,17 @@ pull_request_link = (data, sim_name, repo_slug) ->
 
 
 get_url_text = (repo, make_url, make_text, regex) ->
+  ### Helper function workflow to make link to repo
+
+  Args:
+    repo: object with url & version keys
+    make_url: function to construct a URL
+    make_text: function to construct the link text
+    regex: function which returs a regex for a repo
+
+  Returns:
+    object with link and text keys, null if not a valid link
+  ###
   sequence(
     (x) -> regex().exec(x)
     (x) ->
@@ -262,6 +273,14 @@ get_url_text = (repo, make_url, make_text, regex) ->
 
 
 get_github_gist_link = (repo) ->
+  ### Build link to Github gist repo
+
+  Args:
+    repo: object with url & version keys
+
+  Returns:
+    object with link and text keys, null if not a valid link
+  ###
   regex = ->
     ///
     https?:\/\/               # https or http
@@ -272,21 +291,20 @@ get_github_gist_link = (repo) ->
     $///i                     # case insensitive
 
   make_text = (x) ->
-    "gist:#{x.user}/#{x.repo}@#{repo.version}"
+    "gist:#{x.user}/#{x.repo.substring(0, 8)}@#{repo.version.substring(0, 8)}"
 
   get_url_text(repo, ((x) -> repo.url), make_text, regex)
 
 
 get_github_repo_link = (repo) ->
-  ### Give a repo object return a short text version of the form
+  ### Build link to Github repo
 
   Args:
     repo: object with url & version keys
 
   Returns:
-    object with link and text keys, "Null" if not a valid GitHub link
+    object with link and text keys, null if not a valid link
   ###
-
   regex = ->
     ///
     https?:\/\/               # https or http
@@ -313,6 +331,14 @@ get_github_repo_link = (repo) ->
 
 
 get_bitbucket_link = (repo) ->
+  ### Build link to Bitbucket repo
+
+  Args:
+    repo: object with url & version keys
+
+  Returns:
+    object with link and text keys, null if not a valid link
+  ###
   regex = ->
     ///
     https?:\/\/               # https or http
@@ -339,6 +365,14 @@ get_bitbucket_link = (repo) ->
 
 
 get_generic_link = (repo) ->
+  ### Build link to generic repo
+
+  Args:
+    repo: object with url & version keys
+
+  Returns:
+    object with link and text keys, null if not a valid link
+  ###
   regex = ->
     ///
     https?:\/\/               # https or http
@@ -354,6 +388,14 @@ get_generic_link = (repo) ->
 
 
 repo_html = (x) ->
+  ### Build the html for a repository
+
+  Args:
+    x: object with link and text keys
+
+  Returns:
+    the HTML string
+  ###
   if x?
     "<p><a href='#{x.link}' target='_blank'>#{x.text}</a></p>"
   else

--- a/_includes/coffee/simulation.coffee
+++ b/_includes/coffee/simulation.coffee
@@ -297,13 +297,29 @@ get_github_repo_link = (repo) ->
     (.+)?                     # path
     $///i                     # case insensitive
 
-  make_text = (x) ->
-    "git:#{x.user}/#{x.repo}:/#{x.path}@#{repo.version.substring(0, 8)}"
+  make_text = sequence(
+    (x) -> extend(x, {path:if x.path then ':/' + x.path else x.path})
+    (x) -> "git:#{x.user}/#{x.repo}#{x.path}@#{repo.version.substring(0, 8)}"
+  )
 
   make_url = (x) ->
     "https://www.github.com/#{x.user}/#{x.repo}/tree/#{repo.version}/#{x.path}"
 
   get_url_text(repo, make_url, make_text, regex)
+
+get_generic_link = (repo) ->
+  regex = ->
+    ///
+    https?:\/\/               # https or http
+    (?:[^\s\/]+)?             # website base url
+    (?:\/)                    # divider
+    ([^\s]{1,})              # path
+    ///
+
+  if regex().exec(repo.url)
+    {link:repo.url, text:"#{repo.url}@#{repo.version}"}
+  else
+    null
 
 
 repo_html = (x) ->
@@ -314,7 +330,7 @@ repo_html = (x) ->
 
 
 get_link = sequence(
-  (x) -> map(((f) -> f(x)), [get_github_repo_link, get_github_gist_link])
+  (x) -> map(((f) -> f(x)), [get_github_repo_link, get_github_gist_link, get_generic_link])
   filter((x) -> x?)
   get(0)
 )

--- a/_includes/coffee/simulation.coffee
+++ b/_includes/coffee/simulation.coffee
@@ -211,8 +211,6 @@ pull_request_link = (data, sim_name, repo_slug) ->
     repo_slug: the repo slug from _config.yml
   ###
 
-#"<p style='overflow: auto; white-space: nowrap; max-width: 200px; margin-top: 0px; margin-bottom: 0px;'> <a href='#{x.link}' target='_blank'>#{x.text}</a> </p>"
-
   make_link = (item) ->
     """
     <a href='#{item.pull_request.html_url}'
@@ -233,7 +231,7 @@ pull_request_link = (data, sim_name, repo_slug) ->
       'Null'
 
   call_back = (request, status) ->
-    $('#pull-request').html("<p>" + get_html(request, status) +  "</p>")
+    $('#pull-request').html('<p>' + get_html(request, status) +  '</p>')
 
   sequence(
     (x) -> x.split('/')
@@ -270,8 +268,12 @@ get_github_repo_link = (repo) ->
 
   make_link = sequence(
     (x) -> {url:x[0], user:x[1], repo:x[2], path:x[3]}
-    (x) -> extend(x, {path:if x.path? then ":" + x.path else ""})
-    (x) -> if x.url? then "#{x.user}/#{x.repo}#{x.path}@#{repo.version.substring(0, 8)}" else "Null"
+    (x) -> extend(x, {path:if x.path? then ':' + x.path else ''})
+    (x) ->
+      if x.url?
+        "#{x.user}/#{x.repo}#{x.path}@#{repo.version.substring(0, 8)}"
+      else
+        'Null'
   )
 
   sequence(
@@ -280,27 +282,16 @@ get_github_repo_link = (repo) ->
       if x?
         {link:repo.url, text:make_link(x)}
       else
-        {link:"#", text:"Null"}
+        {link:'#', text:'Null'}
   )(repo.url)
 
-# console.log(get_slug({url:"https://github.com/wd15/pfhub", version:"b0b"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/tree/master/_code", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/blob/master/_code/comment.sh", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://coffeescript-cookbook.github.io/chapters/regular_expressions/", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/chapters/regular_expressions/", version:"b0bb19104d25f53b5f9"}))
-# console.log('testing')
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/tree", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/tree/", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/tree/master", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/tree/master/", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/tree/master/_code", version:"b0bb19104d25f53b5f9"}))
-# console.log(get_slug({url:"https://github.com/wd15/pfhub/tree/master/_code/", version:"b0bb19104d25f53b5f9"}))
 
+repo_link = (link, text) ->
+  "<p> <a href='#{link}' target='_blank'>#{text}</a> </p>"
 
 set_repo = sequence(
   (x) -> get_github_repo_link(x.metadata.implementation.repo)
-  (x) -> $("#repository").html("<p> <a href='#{x.link}' target='_blank'>#{x.text}</a> </p>")
+  (x) -> $('#repository').html(repo_link(x.link, x.text))
 )
 
 get_data = (data, name) ->

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -393,7 +393,7 @@ describe('test get_github_repo_link', ->
       get_github_repo_link(
         {url:'https://github.com/wd15/pfhub', version:'version'}
       ).text,
-      'wd15/pfhub@version'
+      'git:wd15/pfhub@version'
     )
   )
   it('with path', ->
@@ -404,97 +404,46 @@ describe('test get_github_repo_link', ->
           version:'version'
         }
       ).text,
-      'wd15/pfhub:_code@version'
+      'git:wd15/pfhub:/_code@version'
     )
   )
-
 )
 
 
-# describe('result_comparison functions', ->
-#   data = ->
-#     [
-#       {
-#         name:'test'
-#         meta:
-#           {
-#             benchmark:
-#               {
-#                 id:'3a'
-#                 version:'1'
-#               }
-#             data:[
-#               {
-#                 name:'free_energy'
-#                 url:'https://ndownloader.figshare.com/files/10443456'
-#                 format:
-#                   {
-#                     type:'csv'
-#                     parse:
-#                       {
-#                         time:'number'
-#                         free_energy:'number'
-#                       }
-#                   }
-#                 description:'Free energy versus time'
-#                 type:'line'
-#                 transform:[
-#                   {
-#                     type:'formula'
-#                     expr:'datum.time'
-#                     as:'x'
-#                   },
-#                   {
-#                     type:'formula'
-#                     expr:'datum.free_energy'
-#                     as:'y'
-#                   }
-#                 ]
-#               }
-#             ]
-#           }
-#       }
-#     ]
-#   data_raw = ->
-#     [{meta:{benchmark:{id:'3a', version:'1'}}}
-#      {meta:{benchmark:{id:'3a', version:'0'}}}
-#      {meta:{benchmark:{id:'1a', version:'0'}}}
-#      {meta:{benchmark:{id:'2b', version:'1'}}}
-#      {meta:{benchmark:{id:'3a', version:'1'}}}]
-#   chart_data = ->
-#     {
-#       name:'free_energy'
-#       title:'my plot'
-#       mode:'lines'
-#     }
-#   it('simple test', ->
-#     assert.deepEqual(
-#       data()[0].meta.data[0].name
-#       'free_energy'
-#     )
-#   )
-#   it('test get_plotly_data', ->
-#     assert.deepEqual(
-#       get_plotly_data(data(), chart_data()).data[0].x[0]
-#       0
-#     )
-#   )
-#   it('test vega_to_plotly', ->
-#     assert.deepEqual(
-#       vega_to_plotly(chart_data(), 'test')(data()[0].meta.data).name
-#       'test'
-#     )
-#   )
-#   it('test get_comparison_data', ->
-#     assert.deepEqual(
-#       get_comparison_data(chart_data(), data())[0].mode
-#       'lines'
-#     )
-#   )
-#   it('test filter_by_id', ->
-#     assert.deepEqual(
-#       filter_by_id('3a.1')(data_raw()).length
-#       2
-#     )
-#   )
-# )
+describe('test get_github_gist_link', ->
+  it('gist', ->
+    assert.deepEqual(
+      get_github_gist_link(
+        {
+          url:'https://gist.github.com/wd15/7e06a3141a6fbf317b1daf39ef1b0fbb'
+          version:'fc9134b08a9c'
+        }
+      ).text,
+      'gist:wd15/7e06a314@fc9134b0'
+    )
+  )
+)
+
+
+describe('test get_bitbucket_link', ->
+  it('gist', ->
+    assert.deepEqual(
+      get_bitbucket_link(
+        {url:'https://bitbucket.org/ajokisaari/coral/', version:'e8fc74f'}
+      ).text,
+      'git:ajokisaari/coral@e8fc74f'
+    )
+  )
+)
+
+
+describe('test get_generic_link', ->
+  it('gist', ->
+    assert.deepEqual(
+      get_generic_link(
+        {url:'https://bitbucket.org/ajokisaari/coral/', version:'e8fc74f'}
+      ).text,
+      'file:https://bitbucket.org/ajokisaari/coral/@e8fc74f'
+    )
+  )
+)

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -387,6 +387,32 @@ describe('test github_to_raw', ->
   )
 )
 
+describe('test get_github_repo_link', ->
+  it('no path', ->
+    assert.deepEqual(
+      get_github_repo_link(
+        {url:'https://github.com/wd15/pfhub', version:'version'}
+      ),
+      {link:'https://github.com/wd15/pfhub', text:'wd15/pfhub@version'}
+    )
+  )
+  it('with path', ->
+    assert.deepEqual(
+      get_github_repo_link(
+        {
+          url:'https://github.com/wd15/pfhub/tree/master/_code'
+          version:'version'
+        }
+      ),
+      {
+        link:'https://github.com/wd15/pfhub/tree/master/_code'
+        text:'wd15/pfhub:_code@version'
+      }
+    )
+  )
+
+)
+
 
 # describe('result_comparison functions', ->
 #   data = ->

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -392,8 +392,8 @@ describe('test get_github_repo_link', ->
     assert.deepEqual(
       get_github_repo_link(
         {url:'https://github.com/wd15/pfhub', version:'version'}
-      ),
-      {link:'https://github.com/wd15/pfhub', text:'wd15/pfhub@version'}
+      ).text,
+      'wd15/pfhub@version'
     )
   )
   it('with path', ->
@@ -403,11 +403,8 @@ describe('test get_github_repo_link', ->
           url:'https://github.com/wd15/pfhub/tree/master/_code'
           version:'version'
         }
-      ),
-      {
-        link:'https://github.com/wd15/pfhub/tree/master/_code'
-        text:'wd15/pfhub:_code@version'
-      }
+      ).text,
+      'wd15/pfhub:_code@version'
     )
   )
 

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -447,3 +447,15 @@ describe('test get_generic_link', ->
     )
   )
 )
+
+
+describe('test get_link', ->
+  it('broken link', ->
+    assert.deepEqual(
+      get_link(
+        {url:'https://www.google.com', version:'e8fc74f'}
+      ),
+      null
+    )
+  )
+)

--- a/_includes/simulation.html
+++ b/_includes/simulation.html
@@ -12,11 +12,6 @@
         </div>
         <div class="chip" id="github_id">
         </div>
-        <div class="chip" >
-          <img src="{{ site.baseurl }}/images/ic_code_24px.svg"
-               alt="">
-          <span id="code"></span>
-        </div>
       </div>
 
       <div class="row top-buffer">
@@ -52,6 +47,13 @@
                 Upload History
               </td>
               <td id="pull-request">
+              </td>
+            </tr>
+            <tr>
+              <td>
+                Repository
+              </td>
+              <td id="repository">
               </td>
             </tr>
           </tbody>

--- a/css/chimad.css
+++ b/css/chimad.css
@@ -534,3 +534,11 @@ span.plotly-footnote {
     white-space: pre;
     opacity: 1;
 }
+
+#repository p, #pull-request p {
+    overflow: auto;
+    white-space: nowrap;
+    max-width: 200px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+}


### PR DESCRIPTION
Address #880

Generate a sensible link to GitHub and Bitbucket repositories for individual uploads. The repo link is now in the individual upload info table rather than in a chip. Also the URL actually links to the version of the repo given by `metadata.implementation.repo.version`. The works for GitHub repos and Gists as well as Bitbucket. Other URLs are just treated as generic links.

This was an [issue](#880) raised by @guyer.

To review go to the [upload table](http://random-cat-917.surge.sh/simulations/#simulations), click on different uploads and check that the Repository entry is sensible.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-917.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/917)
<!-- Reviewable:end -->
