### PR TITLE
Remove Twitter timeline as no longer supported

### DIFF
--- a/_includes/twitter.html
+++ b/_includes/twitter.html
@@ -1,8 +1,5 @@
-<a class="twitter-timeline"
-   data-height="300"
-   data-width="225"
-   href="https://twitter.com/hashtag/chimadphasefield"
-   data-widget-id="838863917266911234"
-   target="_blank">
-  #chimadphasefield
+<a href="https://twitter.com/intent/tweet?button_hashtag=chimadphasefield&ref_src=twsrc%5Etfw"
+   class="twitter-hashtag-button"
+   data-show-count="false">Tweet #chimadphasefield
 </a>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/css/chimad.css
+++ b/css/chimad.css
@@ -226,7 +226,7 @@ table.striped tbody tr:nth-child(2n+1) {
     position: relative;
     display: inline;
     left: 55px;
-    top: 18px;
+    top: 30px;
     z-index: 1;
 }
 


### PR DESCRIPTION
Address #431

Remove the Twitter timeline using a hashtag as this is non longer
supported. Replace with a simple Tweet button with the
'#chimadphasefield' hashtag.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-935.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/935)
<!-- Reviewable:end -->
