### PR TITLE
Add arXiv link to paywalled BM papers

### DIFF
--- a/wiki/publications.md
+++ b/wiki/publications.md
@@ -12,8 +12,7 @@ title: Publications
 numerical implementations of phase field
 models"](http://dx.doi.org/10.1016/j.commatsci.2016.09.022){:target="_blank"}.
 
-Non pay walled version, see [arXiv
-link](https://arxiv.org/abs/1610.00622).
+[No pay wall preprint version at arXiv](https://arxiv.org/abs/1610.00622)
 
 <iframe width="900"
         height="700"

--- a/wiki/publications.md
+++ b/wiki/publications.md
@@ -12,6 +12,9 @@ title: Publications
 numerical implementations of phase field
 models"](http://dx.doi.org/10.1016/j.commatsci.2016.09.022){:target="_blank"}.
 
+Non pay walled version, see [arXiv
+link](https://arxiv.org/abs/1610.00622).
+
 <iframe width="900"
         height="700"
         src="https://www.sciencedirect.com/science/article/pii/S0927025616304712?via%3Dihub"


### PR DESCRIPTION
Address #478

Only the first paper has an arXiv link not the second paper

See http://random-cat-936.surge.sh/wiki/publications/


<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-936.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/936)
<!-- Reviewable:end -->
