### PR TITLE
Remove progressbar2 as it breaks some Nix builds

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -178,7 +178,6 @@ Create an environment with the required packages
 
     $ source activate test-environment
     $ conda install -n test-environment pillow numpy
-    $ conda install progressbar2
 
 Update the data in the [`hexbin.yaml`]({{ site.links.github
 }}/blob/nist-pages/_data/hexbin.yaml) file. The following format is

--- a/_data/hexbin.py
+++ b/_data/hexbin.py
@@ -3,6 +3,7 @@
 
 import itertools
 from random import shuffle
+import sys
 
 import json
 import io
@@ -10,7 +11,6 @@ import urllib
 
 import yaml
 from PIL import Image
-import progressbar
 import requests
 
 
@@ -67,23 +67,14 @@ def thumbnail_image(image_url, size):
 def hexbin_image(data, x_size, y_size, ni_count, nj_count):
     """Build the combined thumbnails
     """
-    widgets = [
-        progressbar.Percentage(),
-        " ",
-        progressbar.Bar(marker=progressbar.RotatingMarker()),
-        " ",
-        progressbar.ETA(),
-    ]
-
-    pbar = progressbar.ProgressBar(widgets=widgets, maxval=len(data)).start()
+    image_count = len(data)
 
     for counter, datum in enumerate(data):
         image_url = datum["image"]
         image = thumbnail_image(image_url, (x_size, y_size))
         datum["thumbnail"] = image
-        pbar.update(counter + 1)
-
-    pbar.finish()
+        sys.stdout.write(f"\rProgress: {counter} / {image_count}")
+        sys.stdout.flush()
 
     blank_image = Image.new(
         "RGB", (x_size * nj_count, y_size * ni_count), (255, 255, 255, 0)

--- a/_nix/build.nix
+++ b/_nix/build.nix
@@ -27,8 +27,6 @@ in
     pypkgs.flake8
     pypkgs.pylint
     pypi2nix.packages."pykwalify"
-    pypi2nix.packages."vega"
-    pypi2nix.packages."progressbar2"
     pypkgs.pytest
     pypkgs.ipywidgets
     pkgs.nodejs


### PR DESCRIPTION
Address #945

Debian Nix builds are breaking with progressbar2, but it isn't
required for anything important. hexbin.py has been modified not to
use it.



<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-946.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/946)
<!-- Reviewable:end -->
