### PR TITLE
Set the benchmark version using benchmarks.yaml

### DIFF
--- a/_includes/form_overview.html
+++ b/_includes/form_overview.html
@@ -35,7 +35,8 @@
       {% endfor %}
     </select>
     <label class="active" for="benchmark_id">Benchmark ID</label>
-    <input name="fields[benchmark][version]"
+    <input id="version_input"
+           name="fields[benchmark][version]"
            type="hidden"
            value="1">
   </div>

--- a/js/upload_form.coffee
+++ b/js/upload_form.coffee
@@ -215,13 +215,6 @@ if SIM_NAME?
 @update_url = (data) ->
   data.value = github_to_raw(data.value)
 
-make_benchmark_version_ = (benchmark_data) ->
-  sequence(
-    (x) -> x.slice(0, -1) - 1
-    (x) -> benchmark_data[x].revisions[0].version
-  )
-
-
 calc_benchmark_version = (benchmark_data, benchmark_id) ->
   sequence(
     (x) -> x.slice(0, -1) - 1

--- a/js/upload_form.coffee
+++ b/js/upload_form.coffee
@@ -214,3 +214,27 @@ if SIM_NAME?
 
 @update_url = (data) ->
   data.value = github_to_raw(data.value)
+
+make_benchmark_version_ = (benchmark_data) ->
+  sequence(
+    (x) -> x.slice(0, -1) - 1
+    (x) -> benchmark_data[x].revisions[0].version
+  )
+
+
+calc_benchmark_version = (benchmark_data, benchmark_id) ->
+  sequence(
+    (x) -> x.slice(0, -1) - 1
+    (x) -> benchmark_data[x].revisions[0].version
+  )(benchmark_id)
+
+set_benchmark_version = () ->
+  $('#version_input').val(
+    calc_benchmark_version(
+      {{ site.data.benchmarks | jsonify }}
+      $('#benchmark_id').children("option:selected").val()
+    )
+  )
+
+set_benchmark_version()
+$('#benchmark_id').change(set_benchmark_version)


### PR DESCRIPTION
Address #656

Previously the benchmark version was hardwired at 1 on upload. That
now changes to the latest revision in benchmarks.yaml depending on
which benchmark ID is set.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-964.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/964)
<!-- Reviewable:end -->
