### PR TITLE
Switch to version 3 of the Staticman API

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ links:
   github: https://github.com/usnistgov/pfhub
   chat_room: usnistgov/chimad-phase-field
   chat: https://gitter.im/usnistgov/chimad-phase-field
-  staticman_api: https://dev.staticman.net/v3/entry/usnistgov/pfhub/master/simulations
+  staticman_api: https://dev.staticman.net/v3/entry/github/usnistgov/pfhub/master/simulations
   simmeta: https://github.com/usnistgov/pfhub/blob/master/_data/simulations
   maillist: chimad-phase-field@list.nist.gov
   maillist_subscribe: chimad-phase-field+subscribe@list.nist.gov

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ links:
   github: https://github.com/usnistgov/pfhub
   chat_room: usnistgov/chimad-phase-field
   chat: https://gitter.im/usnistgov/chimad-phase-field
-  staticman_api: https://api.staticman.net/v2/entry/usnistgov/pfhub/master/simulations
+  staticman_api: https://dev.staticman.net/v3/entry/usnistgov/pfhub/master/simulations
   simmeta: https://github.com/usnistgov/pfhub/blob/master/_data/simulations
   maillist: chimad-phase-field@list.nist.gov
   maillist_subscribe: chimad-phase-field+subscribe@list.nist.gov


### PR DESCRIPTION
Address #967

Using version 3 allows 5000 hits for PFHub alone rather than 5000 hits
for all projects using Staticman.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-970.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/970)
<!-- Reviewable:end -->
