### PR TITLE
Ensure plots are not cut off on display page

### DIFF
--- a/css/chimad.css
+++ b/css/chimad.css
@@ -163,25 +163,23 @@ table.striped tbody tr:nth-child(2n+1) {
 }
 
 .card.small .card-image {
-    max-height: 70%;
-}
-
-#logo_image .card.small .card-image {
     max-height: 80%;
-    max-width: 80%;
+    min-height: 80%;
+    overflow: auto;
 }
 
 .card.small .card-content.scroll {
     overflow: auto;
-    max-height: 30%;
+    min-height: 20%;
+    max-height: 20%;
+}
+
+.video-container {
+    overflow: visible;
 }
 
 .materialboxed.responsive-img.initialized {
     background-color: white;
-}
-
-.card.small .card-content {
-    max-height: 95%;
 }
 
 .circle {

--- a/css/chimad.css
+++ b/css/chimad.css
@@ -166,12 +166,15 @@ table.striped tbody tr:nth-child(2n+1) {
     max-height: 70%;
 }
 
+#logo_image .card.small .card-image {
+    max-height: 80%;
+    max-width: 80%;
+}
+
 .card.small .card-content.scroll {
     overflow: auto;
     max-height: 30%;
 }
-
-
 
 .materialboxed.responsive-img.initialized {
     background-color: white;

--- a/css/chimad.css
+++ b/css/chimad.css
@@ -172,6 +172,7 @@ table.striped tbody tr:nth-child(2n+1) {
     overflow: auto;
     min-height: 20%;
     max-height: 20%;
+    padding: 10px;
 }
 
 .video-container {

--- a/js/simulation.coffee
+++ b/js/simulation.coffee
@@ -6,7 +6,20 @@
 {% include coffee/vega_extra.coffee %}
 {% include coffee/simulation.coffee %}
 
+
 if SIM_NAME of ALL_DATA
   build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA, AXES_NAMES, REPO)
 else
   window.location = "{{ site.baseurl }}/simulations/notfound/?sim=" + SIM_NAME
+
+
+$('img.materialboxed').each(
+  (index, element) ->
+    $(element).height($(element).parent().height())
+)
+
+
+$('div.video-container iframe').each(
+  (index, element) ->
+    $(element).height($(element).parent().parent().height())
+)


### PR DESCRIPTION
Address #728

Ensure that the bottom of plots are not cut off on individual
simulation result display page.

See, https://random-cat-975.surge.sh/simulations/display/?sim=test_lander for example.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-975.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/975)
<!-- Reviewable:end -->
