### PR TITLE
Make the showcase chart selection persistent

### DIFF
--- a/_includes/coffee/simulation.coffee
+++ b/_includes/coffee/simulation.coffee
@@ -677,7 +677,38 @@ ploterize = (data) ->
   return data
 
 
-build = (data, sim_name, codes_data, chart_data, axes_names, repo_slug) ->
+get_data_name = (sim_data, benchmark_data) ->
+  ### Get the name of the data corresponding to the first chart
+
+  The first chart in the benchmark data corresponds to the chart to be
+  showcased on the individual simulation landing pages.
+
+  Args:
+    sim_data: the simulation data for one simulation
+    benchmark_data: all the benchmark data
+  Returns:
+    the data name such as "free_energy"
+
+  ###
+  sequence(
+    (x) ->
+      if x.benchmark.id isnt 'fake'
+        x.benchmark.id[0..-2] - 1
+      else
+        0
+    (x) -> benchmark_data[x].data[0]
+    (x) -> x.data_name or x.name
+  )(sim_data)
+
+
+build = (data
+sim_name
+codes_data
+chart_data
+axes_names
+repo_slug
+benchmark_data
+) ->
   ### Build the simulation landing page
 
   Args:
@@ -686,6 +717,7 @@ build = (data, sim_name, codes_data, chart_data, axes_names, repo_slug) ->
     codes_data: data about the possible codes
     chart_data: Vega data for 1D charts
     repo_slug: the repo slug from _config.yml
+    benchmark_data: the benchmark data provided to determine the showcase plot
   ###
 
   header(sim_name)
@@ -701,7 +733,12 @@ build = (data, sim_name, codes_data, chart_data, axes_names, repo_slug) ->
   set_repo(data)
 
   result_data = groupBy(((x) -> x.type), data.data)
-  vega_data = vegarize(chart_data, axes_names)(result_data.line)
+
+  vega_data = sequence(
+    sortBy((x) -> x.name isnt get_data_name(data, benchmark_data))
+    vegarize(chart_data, axes_names)
+  )(result_data.line)
+
 
   if vega_data.length > 0
     add_card(add_vega, '#logo_image', with_div = id)(vega_data[0..0])

--- a/_includes/simulation.html
+++ b/_includes/simulation.html
@@ -121,6 +121,7 @@
   var CODES_DATA={{ site.data.codes | jsonify }};
   var AXES_NAMES={{ site.data.axes_names | jsonify }};
   var REPO={{ site.links.repo | jsonify }};
+  var BENCHMARK_DATA={{ site.data.benchmarks | jsonify }};
 </script>
 
 <script src="{{ site.baseurl }}/js/simulation.js"></script>

--- a/js/simulation.coffee
+++ b/js/simulation.coffee
@@ -8,7 +8,7 @@
 
 
 if SIM_NAME of ALL_DATA
-  build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA, AXES_NAMES, REPO)
+  build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA, AXES_NAMES, REPO, BENCHMARK_DATA)
 else
   window.location = "{{ site.baseurl }}/simulations/notfound/?sim=" + SIM_NAME
 

--- a/js/simulation.coffee
+++ b/js/simulation.coffee
@@ -8,7 +8,15 @@
 
 
 if SIM_NAME of ALL_DATA
-  build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA, AXES_NAMES, REPO, BENCHMARK_DATA)
+  build(
+    ALL_DATA[SIM_NAME].meta
+    SIM_NAME
+    CODES_DATA
+    CHART_DATA
+    AXES_NAMES
+    REPO
+    BENCHMARK_DATA
+  )
 else
   window.location = "{{ site.baseurl }}/simulations/notfound/?sim=" + SIM_NAME
 


### PR DESCRIPTION
Address #733

Make the showcase chart selection persistent across all simulations
for a given benchmark. The showcase choice is determined by the first
data item in the benchmarks.yaml file for any given benchmark problem.




<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-977.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/977)
<!-- Reviewable:end -->
