### PR TITLE
Issue976 missing plots on bm7

### DIFF
--- a/_includes/coffee/vega_extra.coffee
+++ b/_includes/coffee/vega_extra.coffee
@@ -68,13 +68,24 @@ add_vega_src = (x) ->
   map(vega_promise, x.data())
 
 
+dl_load = (url) ->
+  try
+    dl.load({url:url})
+  catch NetworkError
+    console.log('NetworkError')
+    console.log('URL:', url)
+    []
+
+
 # read vega data with a url
 read_vega_url = sequence(
-  (x) -> [x.format, dl.load({url:x.url})]
+  (x) -> [x.format, dl_load(x.url)]
   (x) ->
     try
       dl.read(x[1], x[0])
     catch SyntaxError
+      console.log('unable to read vega data')
+      console.log('data:', x)
       null
 )
 

--- a/js/simulation.coffee
+++ b/js/simulation.coffee
@@ -8,7 +8,14 @@
 
 
 if SIM_NAME of ALL_DATA
-  build(ALL_DATA[SIM_NAME].meta, SIM_NAME, CODES_DATA, CHART_DATA, AXES_NAMES, REPO)
+  build(
+    ALL_DATA[SIM_NAME].meta
+    SIM_NAME
+    CODES_DATA
+    CHART_DATA
+    AXES_NAMES
+    REPO
+  )
 else
   window.location = "{{ site.baseurl }}/simulations/notfound/?sim=" + SIM_NAME
 


### PR DESCRIPTION
Address #976

Ensure results comparison pages build when data fails to load. BM 7a.0 was failing to display anything even though only one data set was failing.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-979.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/979)
<!-- Reviewable:end -->
