### PR TITLE
Asynchronous data loading 

### DIFF
--- a/_includes/coffee/result_comparison.coffee
+++ b/_includes/coffee/result_comparison.coffee
@@ -197,7 +197,6 @@ vega_to_plotly = (chart_item, sim_name) ->
     a func that converts Vega to Plotly
   ###
 
-
   efficiency = (name, datum) ->
     if datum is 'x'
       (x) ->
@@ -227,6 +226,12 @@ vega_to_plotly = (chart_item, sim_name) ->
   func_select = ->
     functions[chart_item.func] or get_values
 
+  name_select_filter = (x) ->
+    if chart_item.func is 'efficiency'
+      x.name in ['run_time', 'memory_usage']
+    else
+      x.name is name_select()
+
   name_select = ->
     chart_item.data_name or chart_item.name
 
@@ -240,6 +245,7 @@ vega_to_plotly = (chart_item, sim_name) ->
     }
 
   sequence(
+    filter(name_select_filter)
     map(read_vega_data)
     plotly_dict
   )

--- a/_includes/coffee/result_comparison.coffee
+++ b/_includes/coffee/result_comparison.coffee
@@ -242,6 +242,9 @@ vega_to_plotly = (chart_item, sim_name) ->
       type:chart_item.type
       mode:chart_item.mode
       name:sim_name.substr(0, 15)
+      data:x
+      x_func:func_select()(name_select(), chart_item.x_name or 'x')
+      y_func:func_select()(name_select(), chart_item.y_name or 'y')
     }
 
   sequence(
@@ -249,6 +252,25 @@ vega_to_plotly = (chart_item, sim_name) ->
     map(read_vega_data)
     plotly_dict
   )
+
+
+vega_to_plotly_dl_load = curry(
+  (data, loaded_values) ->
+
+    plotly_dict = (x) ->
+      {
+        x:data.x_func(x)
+        y:data.y_func(x)
+        type:data.type
+        mode:data.mode
+        name:data.name
+      }
+
+    sequence(
+      map(f_read_vega_data(loaded_values))
+      plotly_dict
+    )(data.data)
+)
 
 
 get_comparison_data = curry(
@@ -302,10 +324,35 @@ build = (chart_data, benchmark_id, data) ->
   get_plotly_data_id = get_plotly_data(
     filter_by_id(benchmark_id)(data)
   )
+
+  callback = curry(
+    (x, index, err, loaded_values) ->
+      if err
+        console.log(err)
+        console.log('failed to load data')
+      else
+        x.data[index] = vega_to_plotly_dl_load(x.data[index], loaded_values)
+        Plotly.update(x.div, x.data, x.layout)
+  )
+
   newplot = sequence(
     get_plotly_data_id
     (x) ->
       if x.data.length > 0
         Plotly.newPlot(x.div, x.data, x.layout)
+        map(
+          (index) ->
+            if x.data[index].data.length > 0
+              url = x.data[index].data[0].url
+            else
+              url = null
+            if url?
+              dl.load({url:url}, callback(x, index))
+            else
+              callback(x, index, null, null)
+
+          [0..(x.data.length - 1)]
+        )
+
   )
   -> map(newplot, chart_data)

--- a/_includes/coffee/vega_extra.coffee
+++ b/_includes/coffee/vega_extra.coffee
@@ -72,8 +72,6 @@ dl_load = (url) ->
   try
     dl.load({url:url})
   catch NetworkError
-    console.log('NetworkError')
-    console.log('URL:', url)
     []
 
 
@@ -84,8 +82,6 @@ read_vega_url = sequence(
     try
       dl.read(x[1], x[0])
     catch SyntaxError
-      console.log('unable to read vega data')
-      console.log('data:', x)
       null
 )
 

--- a/_includes/coffee/vega_extra.coffee
+++ b/_includes/coffee/vega_extra.coffee
@@ -71,20 +71,13 @@ add_vega_src = (x) ->
 dl_load = (url) ->
   try
     dl.load({url:url})
-    []
   catch NetworkError
     []
 
 
 # read vega data with a url
-read_vega_url = sequence(
-  (x) -> [x.format, dl_load(x.url)]
-  (x) ->
-    try
-      dl.read(x[1], x[0])
-    catch SyntaxError
-      null
-)
+read_vega_url = (data) ->
+  read_vega_url_no_load(dl_load(data.url), data)
 
 
 vega_transform = (spec) ->
@@ -107,55 +100,43 @@ vega_transform = (spec) ->
 
 
 # read vega data item and apply transforms
-read_vega_data_ = sequence(
-  (x) ->
-    {
-      transforms:map(vega_transform, if x.transform? then x.transform else [])
-      values:if x.url? then read_vega_url(x) else x.values
-    }
-
-  # coffeelint: disable=no_stand_alone_at
-  # coffeelint: disable=missing_fat_arrows
-  (x) -> sequence.apply(@, x.transforms.concat(id))(x.values)
-  # coffeelint: enable=no_stand_alone_at
-  # coffeelint: enable=missing_fat_arrows
-)
-
-
-read_vega_data = (x) ->
-  x.values = read_vega_data_(x)
-  x
-
-# read vega data with a url
-f_read_vega_url = (data, loaded_values) ->
-  sequence(
-    (x) -> [x.format, loaded_values]
-    (x) ->
-      try
-        dl.read(x[1], x[0])
-      catch SyntaxError
-        null
-  )(data)
-
-
-# read vega data item and apply transforms
-f_read_vega_data_ = (loaded_values, data) ->
+read_vega_data_generic = (read_vega_func) ->
   sequence(
     (x) ->
       {
         transforms:map(vega_transform, if x.transform? then x.transform else [])
-        values:if x.url? then f_read_vega_url(x, loaded_values) else x.values
+        values:if x.url? then read_vega_func(x) else x.values
       }
     # coffeelint: disable=no_stand_alone_at
     # coffeelint: disable=missing_fat_arrows
     (x) -> sequence.apply(@, x.transforms.concat(id))(x.values)
     # coffeelint: enable=no_stand_alone_at
     # coffeelint: enable=missing_fat_arrows
-  )(data)
+  )
+
+read_vega_data = (x) ->
+  x.values = read_vega_data_generic(read_vega_url)(x)
+  x
 
 
-f_read_vega_data = curry(
+# read vega data with a url
+read_vega_url_no_load = curry(
   (loaded_values, data) ->
-    data.values = f_read_vega_data_(loaded_values, data)
+    sequence(
+      (x) -> [x.format, loaded_values]
+      (x) ->
+        try
+          dl.read(x[1], x[0])
+        catch SyntaxError
+          null
+    )(data)
+)
+
+
+read_vega_data_no_load = curry(
+  (loaded_values, data) ->
+    data.values = read_vega_data_generic(
+      read_vega_url_no_load(loaded_values)
+    )(data)
     data
 )


### PR DESCRIPTION
Address #981

Load the data asynchrously using `dl.load` with a callback function.
Furthermore, stop loading all the data for each individual item of data in each
graph. This is enormously inefficient and is noticeable on BM 3a.1 for
example which loads really slowly. Overall the load times on the comparison pages should be much better.

Check 3a.1, 4a.1 and 7a.0 to make sure they still work.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-984.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/984)
<!-- Reviewable:end -->
