### PR TITLE
Make anchor headings work

### DIFF
--- a/_includes/coffee/main.coffee
+++ b/_includes/coffee/main.coffee
@@ -173,15 +173,18 @@ to_iso = (x) ->
   (new Date(x)).toISOString().substring(0, 19)
 
 
-make_anchor_html = (baseurl, name) ->
+make_anchor_html = (baseurl, heading) ->
   sequence(
-    (x) -> "#{x}/ABOUT/##{name}"
+    (x) -> heading.trim().replace(/\s+/g, '-').toLowerCase()
     (x) -> """
-      <div>
-        <a href="#{x}"
-           class="hoveranchor">
-           <i class="material-icons tiny">link</i>
+        <div>
+          <a href="#{baseurl}/ABOUT/##{x}"
+             class="hoveranchor">
+             <i class="material-icons tiny">link</i>
+          </a>
+        </div>
+        <a name=#{x}>
+          #{heading}
         </a>
-      </div>
-    """
-  )(baseurl)
+      """
+  )

--- a/_includes/coffee/main.coffee
+++ b/_includes/coffee/main.coffee
@@ -171,3 +171,17 @@ make_table_data = sequence(
 
 to_iso = (x) ->
   (new Date(x)).toISOString().substring(0, 19)
+
+
+make_anchor_html = (baseurl, name) ->
+  sequence(
+    (x) -> "#{x}/ABOUT/##{name}"
+    (x) -> """
+      <div>
+        <a href="#{x}"
+           class="hoveranchor">
+           <i class="material-icons tiny">link</i>
+        </a>
+      </div>
+    """
+  )(baseurl)

--- a/_layouts/essay.html
+++ b/_layouts/essay.html
@@ -4,3 +4,5 @@ layout: default
 
 {% include title.html %}
 {% include textblock.html %}
+
+<script src="{{ site.baseurl }}/js/anchors.js"></script>

--- a/css/chimad.css
+++ b/css/chimad.css
@@ -604,3 +604,20 @@ span.plotly-footnote {
     margin-top: 20px;
     padding: 15px;
 }
+
+a.hoveranchor {
+    opacity:0;
+    position: absolute !important;
+    left: -25px;
+    padding-right: 10px;
+}
+
+.anchor:hover div a.hoveranchor {
+    opacity:1;
+}
+
+.anchor div {
+    position: relative;
+    width: 0;
+    height: 0;
+}

--- a/js/anchors.coffee
+++ b/js/anchors.coffee
@@ -7,11 +7,13 @@
 
 $("h4, h5, h6").each(
   () ->
-    $(this).attr("class", "anchor")
-    $(this).prepend(
+    heading = $(this).text()
+    $(this).text("")
+    $(this).append(
       make_anchor_html(
         "{{ site.baseurl}}"
-        $($(this).children()[0]).attr("name")
+        heading
       )
     )
+    $(this).attr("class", "anchor")
 )

--- a/js/anchors.coffee
+++ b/js/anchors.coffee
@@ -1,0 +1,17 @@
+---
+---
+
+{% include coffee/essential.coffee %}
+{% include coffee/main.coffee %}
+
+
+$("h4, h5, h6").each(
+  () ->
+    $(this).attr("class", "anchor")
+    $(this).prepend(
+      make_anchor_html(
+        "{{ site.baseurl}}"
+        $($(this).children()[0]).attr("name")
+      )
+    )
+)


### PR DESCRIPTION
Allow a small link / anchor to pop up when browsing over headings in the essay layout. This addresses the anchor request by @tkphd [here](https://github.com/usnistgov/pfhub/pull/994#issuecomment-488020221). No need to add a link element now. The Javascript takes care of it.



<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-997.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/997)
<!-- Reviewable:end -->
