### PR TITLE
fix(app): fix allowable CORS origin URL

### DIFF
--- a/_app/main.py
+++ b/_app/main.py
@@ -42,7 +42,7 @@ app = FastAPI()  # pylint: disable=invalid-name
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://127.0.0.1:4000", "https://pages.nist.gov/pfhub"],
+    allow_origins=["http://127.0.0.1:4000", "https://pages.nist.gov"],
     allow_origin_regex=r"http://random-cat-.*\.surge\.sh",
     allow_credentials=True,
     allow_methods=["*"],


### PR DESCRIPTION
Use https://pages.nist.gov in place of https://pages.nist.gov/pfhub
for allow_origins otherwise data doesn't load.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-1020.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1020)
<!-- Reviewable:end -->
