### PR TITLE
feat: allow multiple column names in CSV files

### DIFF
--- a/_data/benchmarks.yaml
+++ b/_data/benchmarks.yaml
@@ -212,7 +212,7 @@
     - name: elastic_free_energy
       data_name: all_data
       x_name: time
-      y_name: elastic_free_energy
+      y_name: [elastic_free_energy, elastic_energy]
       title: Elastic Free Energy
       x_title: Fictive Time
       y_title: "&#8747; <i>f</i><sub>el</sub> <i>dV</i> &nbsp;(aJ)"
@@ -290,7 +290,7 @@
       y_domain: [-30, 30]
       y_scaleanchor: x
       mode: lines
-      func: get_values
+      func: reorder
 
     - name: efficiency
       type: scatter
@@ -314,7 +314,7 @@
         - '&#8747; <i>f</i><sub>el</sub> <i>dV</i>'
         - '&#8497;'
       data_name: all_data
-      columns: ['sim_name', 'a_10', 'a_01', 'a_d', 'elastic_free_energy', 'total_free_energy']
+      columns: ['sim_name', 'a_10', 'a_01', 'a_d', ['elastic_free_energy', 'elastic_energy'], ['total_free_energy', 'total_energy']]
       column_format: ["", ".4g", ".4g", ".4g", ".4g", ".4g"]
 
 

--- a/_data/simulations/Linear_Elasticity_4a/meta.yaml
+++ b/_data/simulations/Linear_Elasticity_4a/meta.yaml
@@ -1,0 +1,84 @@
+_id: aad4b690-a2dd-11e9-9aab-f5cac39b1a42
+metadata:
+  author:
+    first: Shubhajit
+    last: Mondal
+    email: sm44@iitbbs.ac.in
+    github_id: smondal44
+  timestamp: '30 June, 2019'
+  summary: >-
+    In this problem, we solve the linear elasticity problem for circular
+    homogeneous precipitate in effectively infinite domain.
+  implementation:
+    name: Fenics
+    repo:
+      url: 'https://github.com/smondal44/Linear-Elasticity/blob/master/r_Cir_ho_s.py'
+      version: 24704aa86fc2faefe4480f1925124620b6f6a8a1
+    container_url: ''
+  hardware:
+    cpu_architecture: x86_64
+    acc_architecture: non-gpu
+    parallel_model: serial
+    clock_rate: '2.4'
+    cores: '1'
+    nodes: '1'
+benchmark:
+  id: 4a
+  version: '1'
+data:
+  - name: run_time
+    values:
+      - wall_time: '36000'
+        sim_time: '36000'
+  - name: memory_usage
+    values:
+      - unit: KB
+        value: '8388608'
+  - name: contour
+    url: 'https://drive.google.com/open?id=1QCbHstjM024FaGELPsU2KYIN9Owddr62'
+    format:
+      type: csv
+      parse:
+        x: number
+        'y': number
+    description: >-
+      The equilibrium data contains the coordinate of the contour plot at
+      equilibrium. We plot the contour plot at the value of order parameter is
+      equal to 0.5.
+    type: line
+    transform:
+      - type: formula
+        expr: datum.x
+        as: x
+      - type: formula
+        expr: datum.y
+        as: 'y'
+  - name: all_data
+    url: 'https://drive.google.com/open?id=1GDX3YSUwq7-UrMDcy8e-fyTYZthYlmoX'
+    format:
+      type: csv
+      parse:
+        Time: number
+        "Total Energy": number
+    description: >-
+      Here, the data file includes the time, elastic, bulk, gradient and total
+      free energy of the system.
+    type: line
+    transform:
+      - type: formula
+        expr: datum.Time
+        as: x
+      - type: formula
+        expr: "datum['Total Energy']"
+        as: 'y'
+  - name: Energy_plot1
+    url: 'https://drive.google.com/open?id=1AEuagAOSrmO3Zi1SjYTbavTodGCITRLx'
+    type: image
+    description: 'Here, we are plotting the elastic energy as a function of time.'
+  - name: Energy_plot2
+    url: 'https://drive.google.com/open?id=1LMCWTaSS2YsQG2pE7gu2IyEmHVStFMJK'
+    type: image
+    description: >-
+      Here, we are plotting the total free energy of the system as a function of
+      time.
+date: 1562740855

--- a/_includes/coffee/essential.coffee
+++ b/_includes/coffee/essential.coffee
@@ -404,6 +404,28 @@ pluck_arr = curry(
 )
 
 
+pluck_arr_list = curry(
+  (keys, arr) ->
+    ### Pluck a value from a list of dictionaries using a list of keys
+
+    For example
+
+      pluck_arr_list(
+        [{a:1, b:2}, {a:2, b:3}]
+        ['x', 'b']
+
+    should return
+
+      [2, 3]
+    ###
+    sequence(
+      map((x) -> pluck_arr(x, arr))
+      filter((x) -> x[0]?)
+      first
+    )(keys)
+)
+
+
 get = curry(
   (key, dict) ->
     ### Get an element of an object
@@ -442,3 +464,28 @@ map_undef = curry(
 
 transpose = (matrix) ->
   (t[i] for t in matrix) for i in [0...matrix[0].length]
+
+
+modify_keys = curry(
+  (f, x) ->
+    ### Modify keys in dict
+    ###
+    x_ = {}
+    for k, v of x
+      x_[f(k)] = v
+    x_
+)
+
+make_array = (x) ->
+  if typeof(x) is 'object'
+    x
+  else
+    [x]
+
+unzip = (x) ->
+  zip(x...)
+
+juxt = curry(
+  (fs, x) ->
+    (f(x) for f in fs)
+)

--- a/_includes/coffee/simulation.coffee
+++ b/_includes/coffee/simulation.coffee
@@ -764,7 +764,7 @@ appurl
   add_card(add_vega(appurl), '#images', with_div = with_div)(vega_data)
 
   if result_data.contour?
-    contour_data = map(read_vega_data, result_data.contour)
+    contour_data = map(read_vega_data(appurl), result_data.contour)
     plotly_data = map(ploterize, contour_data)
     add_card(add_plotly(appurl), '#images', with_div = with_div)(plotly_data)
 

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -479,3 +479,92 @@ describe('test transpose', ->
     )
   )
 )
+
+
+describe('test pluck_arr_list', ->
+  it('simple', ->
+    assert.deepEqual(
+      pluck_arr_list(['x', 'b'], [{a:1, b:2}, {a:2, b:3}]),
+      [2, 3]
+    )
+  )
+  it('failure', ->
+    assert.deepEqual(
+      pluck_arr_list(['x', 'b'], [{a:1, b:2}, {a:2, x:1}]),
+      [2, undefined]
+    )
+  )
+)
+
+
+describe('test modify_keys', ->
+  it('simple', ->
+    assert.deepEqual(
+      modify_keys(
+        (x) -> x.replace(/\s/g, '_')
+        {'white space':1}
+      )
+      {'white_space':1}
+    )
+  )
+)
+
+
+describe('test make_array', ->
+  it('change', ->
+    assert.deepEqual(
+      make_array('hi')
+      ['hi']
+    )
+  )
+  it('no change', ->
+    assert.deepEqual(
+      make_array(['hi'])
+      ['hi']
+    )
+  )
+)
+
+
+describe('test unzip', ->
+  it('simple', ->
+    assert.deepEqual(
+      unzip([['a', 1], ['b', 2], ['c', 3]])
+      [['a', 'b', 'c'], [1, 2, 3]]
+    )
+  )
+)
+
+
+describe('test juxt', ->
+  it('simple', ->
+    assert.deepEqual(
+      juxt([
+        (x) -> x * 2
+        (x) -> x / 2
+        ], 2.0)
+      [4.0, 1.0]
+    )
+  )
+)
+
+
+describe('test reorder', ->
+  it('simple', ->
+    assert.deepEqual(
+      reorder(
+        'data'
+        'x'
+        'y'
+        [
+          {
+            name:'data'
+            values:
+              [{x:0.0, y:1.0}, {x:1.0, y:0.0}, {x:-1.0, y:0.0}]
+          }
+        ]
+      )
+      [[1, 0, -1], [0, 1, 0]]
+    )
+  )
+)


### PR DESCRIPTION
Allow multiple different column names in CSV files for BM4, but the implementation is generic so will work for other benchmarks as well. Also, allow disordered points for the precipitate boundary contour plot.

For example, this [upload](http://random-cat-1021.surge.sh/simulations/display/?sim=Linear_Elasticity_4a) now [works](http://random-cat-1021.surge.sh/simulations/4a.1/) despite the [data](https://drive.google.com/file/d/1GDX3YSUwq7-UrMDcy8e-fyTYZthYlmoX/view) having incorrect column names as specified in the [spec](http://random-cat-1021.surge.sh/benchmarks/benchmark4.ipynb/#Evolving-Data-Format). 

Also, the contour points are ordered correctly, see [this](http://random-cat-1021.surge.sh/simulations/4a.1/) instead of incorrectly like [this](https://random-cat-1006.surge.sh/simulations/4a.1/).

Note that the contour points have not been ordered correctly on [this page yet](http://random-cat-1021.surge.sh/simulations/display/?sim=Linear_Elasticity_4a). This page still uses Vega plots which will be phased out so I'm not putting effort into dealing with that.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: http://random-cat-1021.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1021)
<!-- Reviewable:end -->
