### PR TITLE
fix: use https for Surge link instead of http 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -20,4 +20,4 @@ These changes can be [viewed live][live-site].
 **Remember to tear down the [live site][live-site] when merging
 or closing this pull request.**
 
-[live-site]: http://random-cat-{pull-request-number}.surge.sh
+[live-site]: https://random-cat-{pull-request-number}.surge.sh


### PR DESCRIPTION
<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: https://random-cat-1022.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1022)
<!-- Reviewable:end -->
