### PR TITLE
build(staticman): use wd15-staticman.herokuapp.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ links:
   github: https://github.com/usnistgov/pfhub
   chat_room: usnistgov/chimad-phase-field
   chat: https://gitter.im/usnistgov/chimad-phase-field
-  staticman_api: https://dev.staticman.net/v3/entry/github/usnistgov/pfhub/master/simulations
+  staticman_api: https://wd15-staticman.herokuapp.com/v3/entry/github/usnistgov/pfhub/master/simulations
   simmeta: https://github.com/usnistgov/pfhub/blob/master/_data/simulations
   maillist: chimad-phase-field@list.nist.gov
   maillist_subscribe: chimad-phase-field+subscribe@list.nist.gov


### PR DESCRIPTION
Address #899

Use wd15-staticman.herokuapp.com instead of https://dev.staticman.net
for new PFHub Staticman instance hosted on Heroku.

Running up against "Application Error' when using https://dev.staticman.net, which is the public instance of Staticman. Decided to roll out a PFHub dedicated Staticman hosted on the free tier of Heroku. Hopefully, this will be more stable going forward. Also, will give us more flexibility to adjust the way Staticman works and more easily interact with out Python backend app.

Currently using [this version](https://github.com/wd15/staticman/tree/production) of staticman.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: https://random-cat-1025.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1025)
<!-- Reviewable:end -->
