### PR TITLE
BM8 results page

### DIFF
--- a/_data/benchmarks.yaml
+++ b/_data/benchmarks.yaml
@@ -406,3 +406,49 @@
       mode: lines
       x_dtick: 1
       y_dtick: 1
+
+- title: Nucleation
+  description: Nucleation benchmark
+  image: https://user-images.githubusercontent.com/1986844/66938477-396aff80-f00f-11e9-8c21-b59356a3b0e0.png
+  num: 8
+  revisions:
+    - version: 0
+      variations: [a, b, c, d]
+      event:
+        name: Hackathon 5
+        url: "benchmarks/benchmark8.ipynb"
+      url: "benchmarks/benchmark8.ipynb"
+      commit:
+        sha: "e19007361211"
+        url: "benchmarks/benchmark8.ipynb"
+  data:
+    - name: free_energy
+      title: Free Energy
+      x_title: Time
+      y_title: Free Energy
+      x_scale: linear
+      y_scale: linear
+      type: scatter
+      mode: lines
+      func: get_values
+
+    - name: solid_fraction
+      title: Solid Fraction
+      y_title: Solid Fraction
+      x_title: Time
+      x_scale: linear
+      y_scale: linear
+      type: scatter
+      mode: lines
+      func: get_values
+
+    - name: efficiency
+      type: scatter
+      x_scale: log
+      y_scale: log
+      x_title: 'Normalized Wall Time *'
+      y_title: 'Memory Usage (KB)'
+      title: Efficiency
+      mode: markers
+      footnote: "<span class='plotly-footnote' >* Wall time divided by the total simulated time.</span>"
+      func: efficiency

--- a/_data/simulations/example/schema.yaml
+++ b/_data/simulations/example/schema.yaml
@@ -59,7 +59,7 @@ mapping:
     mapping:
       "id":
         type: str
-        enum: ["1a", "1b", "1c", "1d", "2a", "2b", "2c", "2d", "3a", "6a", "6b", "7a", "7b", "7c", "4a", "4b", "4c", "4d", "4e", "4f", "4g", "4h", "fake"]
+        enum: ["1a", "1b", "1c", "1d", "2a", "2b", "2c", "2d", "3a", "6a", "6b", "7a", "7b", "7c", "4a", "4b", "4c", "4d", "4e", "4f", "4g", "4h", "fake", "8a", "8b", "8c", "8d"]
         required: True
       "version":
         type: number

--- a/_data/simulations/fipy_8a/meta.yaml
+++ b/_data/simulations/fipy_8a/meta.yaml
@@ -1,0 +1,73 @@
+_id: 93113e00-0c5e-11e8-b653-4f1ed6519c85
+benchmark:
+  id: 8a
+  version: '0'
+data:
+- name: run_time
+  values:
+  - sim_time: '1'
+    wall_time: '1'
+- name: memory_usage
+  values:
+  - unit: KB
+    value: '1'
+- description: Free energy versus time
+  format:
+    parse:
+      energy: number
+      time: number
+    type: tsv
+  name: free_energy
+  transform:
+  - as: x
+    expr: datum.time
+    type: formula
+  - as: y
+    expr: datum.energy
+    type: formula
+  type: line
+  url: https://drive.google.com/file/d/1j1aEXuES2bcw7MoYodkGVCIOeue12Om6/view?usp=sharing
+- description: Solid fraction versus time
+  format:
+    parse:
+      fraction: number
+      time: number
+    type: tsv
+  name: solid_fraction
+  transform:
+  - as: x
+    expr: datum.time
+    type: formula
+  - as: y
+    expr: datum.fraction
+    type: formula
+  type: line
+  url: https://drive.google.com/file/d/1j1aEXuES2bcw7MoYodkGVCIOeue12Om6/view?usp=sharing
+- description: A puppy picture
+  name: image
+  type: image
+  url: https://user-images.githubusercontent.com/1986844/66938477-396aff80-f00f-11e9-8c21-b59356a3b0e0.png
+date: 1518046097
+layout: post
+message: ' '
+metadata:
+  author:
+    email: jon.guyer@nist.gov
+    first: Jon
+    github_id: wd15
+    last: Guyer
+  hardware:
+    acc_architecture: none
+    clock_rate: '3.2'
+    cores: '1'
+    cpu_architecture: x86_64
+    nodes: '1'
+    parallel_model: serial
+  implementation:
+    container_url: ''
+    name: fipy
+    repo:
+      url: https://gist.github.com/wd15/7e06a3141a6fbf317b1daf39ef1b0fbb
+      version: fc9134b08a9c
+  summary: FiPy implementation of benchmark 8a
+  timestamp: 2 February, 2018

--- a/benchmarks/benchmark7.ipynb
+++ b/benchmarks/benchmark7.ipynb
@@ -82,14 +82,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<a href=\"https://github.com/stvdwtt/chimad-phase-field/raw/benchmark_7_for_merging/benchmarks/benchmark7.ipynb\"\n",
+       "<a href=\"https://github.com/usnistgov/pfhub/raw/master/benchmarks/benchmark7.ipynb\"\n",
        "   download>\n",
        "<button type=\"submit\">Download Notebook</button>\n",
        "</a>\n"
@@ -98,7 +98,7 @@
        "<IPython.core.display.HTML object>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -107,7 +107,7 @@
     "from IPython.display import HTML\n",
     "\n",
     "HTML('''\n",
-    "<a href=\"https://github.com/stvdwtt/chimad-phase-field/raw/benchmark_7_for_merging/benchmarks/benchmark7.ipynb\"\n",
+    "<a href=\"https://github.com/usnistgov/pfhub/raw/master/benchmarks/benchmark7.ipynb\"\n",
     "   download>\n",
     "<button type=\"submit\">Download Notebook</button>\n",
     "</a>\n",

--- a/benchmarks/benchmark7.ipynb.raw.html
+++ b/benchmarks/benchmark7.ipynb.raw.html
@@ -26,10 +26,10 @@
 
 
 
-<div id="a7a881bc-01c0-443c-a6eb-fc03815ba4ba"></div>
+<div id="4ab3ef2d-55d3-4a5c-8f5b-2c609f089794"></div>
 <div class="output_subarea output_javascript ">
 <script type="text/javascript">
-var element = $('#a7a881bc-01c0-443c-a6eb-fc03815ba4ba');
+var element = $('#4ab3ef2d-55d3-4a5c-8f5b-2c609f089794');
     MathJax.Hub.Config({
       TeX: { equationNumbers: { autoNumber: "AMS" } }
     });
@@ -106,13 +106,13 @@ $( document ).ready(code_toggle);
 </div>
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
-<div class="prompt input_prompt">In&nbsp;[3]:</div>
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
 <div class="inner_cell">
     <div class="input_area">
 <div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">IPython.display</span> <span class="k">import</span> <span class="n">HTML</span>
 
 <span class="n">HTML</span><span class="p">(</span><span class="s1">&#39;&#39;&#39;</span>
-<span class="s1">&lt;a href=&quot;https://github.com/stvdwtt/chimad-phase-field/raw/benchmark_7_for_merging/benchmarks/benchmark7.ipynb&quot;</span>
+<span class="s1">&lt;a href=&quot;https://github.com/usnistgov/pfhub/raw/master/benchmarks/benchmark7.ipynb&quot;</span>
 <span class="s1">   download&gt;</span>
 <span class="s1">&lt;button type=&quot;submit&quot;&gt;Download Notebook&lt;/button&gt;</span>
 <span class="s1">&lt;/a&gt;</span>
@@ -129,13 +129,13 @@ $( document ).ready(code_toggle);
 
 <div class="output_area">
 
-<div class="prompt output_prompt">Out[3]:</div>
+<div class="prompt output_prompt">Out[1]:</div>
 
 
 
 <div class="output_html rendered_html output_subarea output_execute_result">
 
-<a href="https://github.com/stvdwtt/chimad-phase-field/raw/benchmark_7_for_merging/benchmarks/benchmark7.ipynb"
+<a href="https://github.com/usnistgov/pfhub/raw/master/benchmarks/benchmark7.ipynb"
    download>
 <button type="submit">Download Notebook</button>
 </a>

--- a/benchmarks/benchmark8.ipynb
+++ b/benchmarks/benchmark8.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "    MathJax.Hub.Config({\n",
+       "      TeX: { equationNumbers: { autoNumber: \"AMS\" } }\n",
+       "    });"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%javascript\n",
+    "    MathJax.Hub.Config({\n",
+    "      TeX: { equationNumbers: { autoNumber: \"AMS\" } }\n",
+    "    });"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>\n",
+       "code_show=true; \n",
+       "function code_toggle() {\n",
+       " if (code_show){\n",
+       " $('div.input').hide();\n",
+       " $('div.prompt').hide();\n",
+       " } else {\n",
+       " $('div.input').show();\n",
+       "$('div.prompt').show();\n",
+       " }\n",
+       " code_show = !code_show\n",
+       "} \n",
+       "$( document ).ready(code_toggle);\n",
+       "</script>\n",
+       "<form action=\"javascript:code_toggle()\"><input type=\"submit\" value=\"Code Toggle\"></form>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import HTML\n",
+    "\n",
+    "HTML('''<script>\n",
+    "code_show=true; \n",
+    "function code_toggle() {\n",
+    " if (code_show){\n",
+    " $('div.input').hide();\n",
+    " $('div.prompt').hide();\n",
+    " } else {\n",
+    " $('div.input').show();\n",
+    "$('div.prompt').show();\n",
+    " }\n",
+    " code_show = !code_show\n",
+    "} \n",
+    "$( document ).ready(code_toggle);\n",
+    "</script>\n",
+    "<form action=\"javascript:code_toggle()\"><input type=\"submit\" value=\"Code Toggle\"></form>''')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Disable until merge\n",
+    "#from IPython.display import HTML\n",
+    "#\n",
+    "#HTML('''\n",
+    "#<a href=\"https://github.com/usnistgov/pfhub/raw/master/benchmarks/benchmark8.ipynb\"\n",
+    "#   download>\n",
+    "#<button type=\"submit\">Download Notebook</button>\n",
+    "#</a>\n",
+    "#''')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Benchmark Problem 8: Nucleation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "{% include jupyter_benchmark_table.html num=\"[8]\" revision=0 %}"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import HTML\n",
+    "\n",
+    "HTML('''{% include jupyter_benchmark_table.html num=\"[8]\" revision=0 %}''')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Under construction"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/benchmarks/benchmark8.ipynb.md
+++ b/benchmarks/benchmark8.ipynb.md
@@ -1,0 +1,6 @@
+---
+title: ""
+layout: ipython
+---
+
+{% include_relative benchmark8.ipynb.raw.html %}

--- a/benchmarks/benchmark8.ipynb.raw.html
+++ b/benchmarks/benchmark8.ipynb.raw.html
@@ -1,0 +1,179 @@
+
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="o">%%</span><span class="nx">javascript</span>
+    <span class="nx">MathJax</span><span class="p">.</span><span class="nx">Hub</span><span class="p">.</span><span class="nx">Config</span><span class="p">({</span>
+      <span class="nx">TeX</span><span class="o">:</span> <span class="p">{</span> <span class="nx">equationNumbers</span><span class="o">:</span> <span class="p">{</span> <span class="nx">autoNumber</span><span class="o">:</span> <span class="s2">&quot;AMS&quot;</span> <span class="p">}</span> <span class="p">}</span>
+    <span class="p">});</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+<div class="prompt"></div>
+
+
+
+
+
+<div id="6fd4b22a-7c12-4675-ae41-5b37face57b0"></div>
+<div class="output_subarea output_javascript ">
+<script type="text/javascript">
+var element = $('#6fd4b22a-7c12-4675-ae41-5b37face57b0');
+    MathJax.Hub.Config({
+      TeX: { equationNumbers: { autoNumber: "AMS" } }
+    });
+</script>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[2]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">IPython.display</span> <span class="k">import</span> <span class="n">HTML</span>
+
+<span class="n">HTML</span><span class="p">(</span><span class="s1">&#39;&#39;&#39;&lt;script&gt;</span>
+<span class="s1">code_show=true; </span>
+<span class="s1">function code_toggle() {</span>
+<span class="s1"> if (code_show){</span>
+<span class="s1"> $(&#39;div.input&#39;).hide();</span>
+<span class="s1"> $(&#39;div.prompt&#39;).hide();</span>
+<span class="s1"> } else {</span>
+<span class="s1"> $(&#39;div.input&#39;).show();</span>
+<span class="s1">$(&#39;div.prompt&#39;).show();</span>
+<span class="s1"> }</span>
+<span class="s1"> code_show = !code_show</span>
+<span class="s1">} </span>
+<span class="s1">$( document ).ready(code_toggle);</span>
+<span class="s1">&lt;/script&gt;</span>
+<span class="s1">&lt;form action=&quot;javascript:code_toggle()&quot;&gt;&lt;input type=&quot;submit&quot; value=&quot;Code Toggle&quot;&gt;&lt;/form&gt;&#39;&#39;&#39;</span><span class="p">)</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+<div class="prompt output_prompt">Out[2]:</div>
+
+
+
+<div class="output_html rendered_html output_subarea output_execute_result">
+<script>
+code_show=true; 
+function code_toggle() {
+ if (code_show){
+ $('div.input').hide();
+ $('div.prompt').hide();
+ } else {
+ $('div.input').show();
+$('div.prompt').show();
+ }
+ code_show = !code_show
+} 
+$( document ).ready(code_toggle);
+</script>
+<form action="javascript:code_toggle()"><input type="submit" value="Code Toggle"></form>
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="c1"># Disable until merge</span>
+<span class="c1">#from IPython.display import HTML</span>
+<span class="c1">#</span>
+<span class="c1">#HTML(&#39;&#39;&#39;</span>
+<span class="c1">#&lt;a href=&quot;https://github.com/usnistgov/pfhub/raw/master/benchmarks/benchmark8.ipynb&quot;</span>
+<span class="c1">#   download&gt;</span>
+<span class="c1">#&lt;button type=&quot;submit&quot;&gt;Download Notebook&lt;/button&gt;</span>
+<span class="c1">#&lt;/a&gt;</span>
+<span class="c1">#&#39;&#39;&#39;)</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h1 id="Benchmark-Problem-8:-Nucleation">Benchmark Problem 8: Nucleation<a class="anchor-link" href="#Benchmark-Problem-8:-Nucleation">&#182;</a></h1>
+</div>
+</div>
+</div>
+<div class="cell border-box-sizing code_cell rendered">
+<div class="input">
+<div class="prompt input_prompt">In&nbsp;[1]:</div>
+<div class="inner_cell">
+    <div class="input_area">
+<div class=" highlight hl-ipython3"><pre><span></span><span class="kn">from</span> <span class="nn">IPython.display</span> <span class="k">import</span> <span class="n">HTML</span>
+
+<span class="n">HTML</span><span class="p">(</span><span class="s1">&#39;&#39;&#39;{</span><span class="si">% i</span><span class="s1">nclude jupyter_benchmark_table.html num=&quot;[8]&quot; revision=0 %}&#39;&#39;&#39;</span><span class="p">)</span>
+</pre></div>
+
+</div>
+</div>
+</div>
+
+<div class="output_wrapper">
+<div class="output">
+
+
+<div class="output_area">
+
+<div class="prompt output_prompt">Out[1]:</div>
+
+
+
+<div class="output_html rendered_html output_subarea output_execute_result">
+{% include jupyter_benchmark_table.html num="[8]" revision=0 %}
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+<div class="cell border-box-sizing text_cell rendered"><div class="prompt input_prompt">
+</div>
+<div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<h1 id="Under-construction">Under construction<a class="anchor-link" href="#Under-construction">&#182;</a></h1>
+</div>
+</div>
+</div>
+ 
+

--- a/benchmarks/benchmark8a.0.ipynb.md
+++ b/benchmarks/benchmark8a.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark8.ipynb/
+---

--- a/benchmarks/benchmark8b.0.ipynb.md
+++ b/benchmarks/benchmark8b.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark8.ipynb/
+---

--- a/benchmarks/benchmark8c.0.ipynb.md
+++ b/benchmarks/benchmark8c.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark8.ipynb/
+---

--- a/benchmarks/benchmark8d.0.ipynb.md
+++ b/benchmarks/benchmark8d.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark8.ipynb/
+---

--- a/simulations/8a.0.html
+++ b/simulations/8a.0.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+
+{% assign benchmark_id = page.url | remove: '/simulations/' | remove: '/' %}
+{% include result_comparison.html benchmark_id=benchmark_id %}

--- a/simulations/8b.0.html
+++ b/simulations/8b.0.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+
+{% assign benchmark_id = page.url | remove: '/simulations/' | remove: '/' %}
+{% include result_comparison.html benchmark_id=benchmark_id %}

--- a/simulations/8c.0.html
+++ b/simulations/8c.0.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+
+{% assign benchmark_id = page.url | remove: '/simulations/' | remove: '/' %}
+{% include result_comparison.html benchmark_id=benchmark_id %}

--- a/simulations/8d.0.html
+++ b/simulations/8d.0.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+
+{% assign benchmark_id = page.url | remove: '/simulations/' | remove: '/' %}
+{% include result_comparison.html benchmark_id=benchmark_id %}


### PR DESCRIPTION
Add benchmark 8 results page

Address #1053

Review this mostly: https://random-cat-1056.surge.sh/simulations/8a.0/

A few other issues were raised implementing this, #1057 and #1058 

Upload form works for BM8 as well, #1059

Note that I'm confused about how many variations we need and how to structure those. Right now I've included 4, but it's more complicated then that. We probably don't need to resolve this with this PR, however. Probably best to resolve when we add the specification.

<!--
  Text below provides an easy link for PR reviewers to click.
  After submitting your request, change the `[live-site]:` URL
  at the end with the actual `{pull-request-number}` assigned
  by GitHub, without the '#'.
-->

These changes can be [viewed live][live-site].

**Remember to tear down the [live site][live-site] when merging
or closing this pull request.**

[live-site]: https://random-cat-1056.surge.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1056)
<!-- Reviewable:end -->
