### PR TITLE
fix: ensure contour plot points are ordered

### DIFF
--- a/_data/benchmarks.yaml
+++ b/_data/benchmarks.yaml
@@ -160,7 +160,7 @@
       y_domain: [0, 500]
       y_scaleanchor: x
       mode: lines
-      func: get_values
+      func: reorder_offset
 
     - name: efficiency
       type: scatter

--- a/_data/simulations/memphis_3a/meta.yaml
+++ b/_data/simulations/memphis_3a/meta.yaml
@@ -1,0 +1,103 @@
+_id: 1d52b120-493e-11ea-a7b1-1d746210c628
+metadata:
+  author:
+    first: Remi
+    last: Dingreville
+    email: rdingre@sandia.gov
+    github_id: rdingre
+  timestamp: '3 February, 2020'
+  summary: Memphis verification and validation against benchmark
+  implementation:
+    name: memphis
+    repo:
+      url: 'https://github.com/memphis-snl/memphis'
+      version: e168825
+    container_url: ''
+  hardware:
+    cpu_architecture: x86_64
+    acc_architecture: none
+    parallel_model: distributed
+    clock_rate: '2.6'
+    cores: '16'
+    nodes: '1'
+benchmark:
+  id: 3a
+  version: '1'
+data:
+  - name: run_time
+    values:
+      - wall_time: '8215'
+        sim_time: '1500'
+  - name: memory_usage
+    values:
+      - unit: KB
+        value: '865610'
+  - name: free_energy
+    url: >-
+      https://raw.githubusercontent.com/memphis-snl/memphis/master/benchmark/BM_003/3a_free-energy_explicit-euler.csv
+    format:
+      type: csv
+      parse:
+        time: number
+        free_energy: number
+    description: memphis_3a_free_energy
+    type: line
+    transform:
+      - type: formula
+        expr: datum.time
+        as: x
+      - type: formula
+        expr: datum.free_energy
+        as: 'y'
+  - name: solid_fraction
+    url: >-
+      https://raw.githubusercontent.com/memphis-snl/memphis/master/benchmark/BM_003/3a_solid-fraction_explicit-euler.csv
+    format:
+      type: csv
+      parse:
+        time: number
+        solid_fraction: number
+    description: memphis_3a_solid_fraction
+    type: line
+    transform:
+      - type: formula
+        expr: datum.time
+        as: x
+      - type: formula
+        expr: datum.solid_fraction
+        as: 'y'
+  - name: tip_position
+    url: >-
+      https://raw.githubusercontent.com/memphis-snl/memphis/master/benchmark/BM_003/3a_tip-position_explicit-euler.csv
+    format:
+      type: csv
+      parse:
+        time: number
+        tip_position: number
+    description: memphis_3a_tip_position
+    type: line
+    transform:
+      - type: formula
+        expr: datum.time
+        as: x
+      - type: formula
+        expr: datum.tip_position
+        as: 'y'
+  - name: phase_field_1500
+    url: >-
+      https://raw.githubusercontent.com/memphis-snl/memphis/master/benchmark/BM_003/3a_contour_explicit-euler.csv
+    format:
+      type: csv
+      parse:
+        x: number
+        'y': number
+    description: memphis_3a_pf_1500
+    type: line
+    transform:
+      - type: formula
+        expr: datum.x
+        as: x
+      - type: formula
+        expr: datum.y
+        as: 'y'
+date: 1581034171

--- a/_includes/coffee/test.coffee
+++ b/_includes/coffee/test.coffee
@@ -553,6 +553,7 @@ describe('test reorder', ->
   it('simple', ->
     assert.deepEqual(
       reorder(
+        [0, 0]
         'data'
         'x'
         'y'


### PR DESCRIPTION
Required to merge #1167
 
An upload had disordered points for the solid / liquid boundary contour plot in BM3. This issue had been fixed for BM4, but not ported to BM3. It required moving the origin away from the dendrite to ensure no overlapping angles.

To review, look at both [BM3](https://random-cat-1175.surge.sh/simulations/3a.1/) and [BM4.a](https://random-cat-1175.surge.sh/simulations/4a.1/) as this uses point reordering as well.

Note that in #1167 the `memphis_3a` result [has disordered points](https://random-cat-1167.surge.sh/simulations/3a.1/) and I think `PRISMS_PF_sp`. These should both be corrected now.

A comment will appear below when the live site is built. This normally
takes a few minutes.

**Remember to tear down the live site when merging or closing this
pull request.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1175)
<!-- Reviewable:end -->
