### PR TITLE
fix: two box app fixes

### DIFF
--- a/_apps/box/main.py
+++ b/_apps/box/main.py
@@ -90,6 +90,10 @@ def get_json(filename: str) -> str:
 def upload_to_box(upload_file: UploadFile, folder_name: str) -> dict:
     """Upload a file to box
 
+    Uploads are to a subfolder of the pfhub app called
+    "pfhub_uploads", which is shared with "daniel.wheeler@nist.gov",
+    see share.py for a script to do that.
+
     Args:
       upload_file: an UploadFile object
       folder_name: the folder to dump the file to
@@ -103,10 +107,12 @@ def upload_to_box(upload_file: UploadFile, folder_name: str) -> dict:
         juxt(get("boxAppSettings"), identity, get_in(["boxAppSettings", "appAuth"])),
         lambda x: get_auth(*x),
         Client,
-        lambda x: x.folder(folder_id="0"),
+        lambda x: x.folder(folder_id="104320745165"),
         lambda x: x.create_subfolder(folder_name),
         lambda x: x.upload_stream(upload_file.file, upload_file.filename),
-        lambda x: dict(file_id=x.id, download_link=x.get_download_url()),
+        lambda x: dict(
+            file_id=x.id, download_link=x.get_download_url(), folder_name=folder_name
+        ),
     )
 
 

--- a/_apps/box/share.py
+++ b/_apps/box/share.py
@@ -1,0 +1,29 @@
+"""Generate a shared Box folder to store data in an admins' account
+
+"""
+
+from toolz.curried import juxt, get, get_in, identity
+from boxsdk.object.collaboration import CollaborationRole
+
+from main import get_config_filename, get_json, get_auth, Client
+
+
+def shared_folder():
+    """Generate a shared Box folder
+    """
+    fname = get_config_filename()
+    json = get_json(fname)
+    data = juxt(get("boxAppSettings"), identity, get_in(["boxAppSettings", "appAuth"]))(
+        json
+    )
+    auth = get_auth(*data)
+    client = Client(auth)
+
+    root_folder = client.folder(folder_id="0")
+    pfhub_uploads = root_folder.create_subfolder("pfhub_uploads")
+    pfhub_uploads.add_collaborator("daniel.wheeler@nist.gov", CollaborationRole.EDITOR)
+    print("pfhub shared folder id:", pfhub_uploads.id)
+
+
+if __name__ == "__main__":
+    shared_folder()

--- a/_apps/box/test.py
+++ b/_apps/box/test.py
@@ -51,7 +51,9 @@ class MockStream(Mock):
     def get_data(self):
         """Confirm the test data
         """
-        return dict(file_id=self.id, download_link=self.get_download_url())
+        return dict(
+            file_id=self.id, download_link=self.get_download_url(), folder_name="test"
+        )
 
 
 class MockFolder(Mock):
@@ -133,8 +135,8 @@ def test_upload_endpoint(*_):
             write_json(data=dict(a=1)),
             lambda x: dict(fileb=open(x, "rb")),
             lambda x: client.post(f"/upload/", files=x),
-            lambda x: x.json(),
-            equals(MockStream().get_data()),
+            lambda x: x.json()["download_link"],
+            equals(MockStream().get_data()["download_link"]),
         )
 
 

--- a/_data/simulations/example/meta.yaml
+++ b/_data/simulations/example/meta.yaml
@@ -19,6 +19,7 @@ data:
     type: formula
   type: line
   url: https://gist.githubusercontent.com/tkphd/8659310fb61efba6c97df42e12382924/raw/98fcbed6c526092ec561dc11904c3754ccbfd880/mmsp_1a_wrksttn.csv
+  boxuid: "00000000-0000-4000-a000-000000000000"
 - name: run_time
   values:
   - sim_time: 53333.3

--- a/_data/simulations/example/schema.yaml
+++ b/_data/simulations/example/schema.yaml
@@ -44,6 +44,10 @@ mapping:
           "url":
             type: str
             required: False
+          "boxuid":
+            pattern: \b[0-9a-f]{8}\-[0-9a-f]{4}\-4[0-9a-f]{3}\-[89ab][0-9a-f]{3}\-[0-9a-f]{12}\b
+            type: str
+            required: False
           "transform":
             type: any
             required: False

--- a/_includes/coffee/main.coffee
+++ b/_includes/coffee/main.coffee
@@ -198,7 +198,7 @@ make_form_data = (name, file) ->
   x
 
 
-@send_to_box = (tag, thiss) ->
+@send_to_box = (tag, thiss, boxtag) ->
   ### Send file from input element to box and then add link to
   Staticman input value
 
@@ -206,7 +206,10 @@ make_form_data = (name, file) ->
     tag: the tag with the input element with the named value to upload
       to Staticman
     thiss: the file input element
+    boxtag: the tag to the box UID input element
   ###
+  $('#upload-form-submit').prop('disabled', true)
+
   fetch(
     '{{ site.links.box_app }}' + '/upload/'
     {
@@ -220,9 +223,12 @@ make_form_data = (name, file) ->
   ).then(
     (data) ->
       $(tag).val(data['download_link'])
+      $(boxtag).val(data['folder_name'])
+      $('#upload-form-submit').prop('disabled', false)
   ).catch(
     (error) ->
       console.log(error)
+      $('#upload-form-submit').prop('disabled', false)
   )
 
 

--- a/_includes/data_input.html
+++ b/_includes/data_input.html
@@ -55,9 +55,9 @@
           id="data-upload-{{ counter }}"
           oninput="swap([['#data-link-div-{{ counter }}', '#data-upload-div-{{ counter }}', 'hidden'], ['#data-upload-input-{{ counter }}', '#data-link-input-{{ counter }}', 'required']])" />
         <label for="data-upload-{{ counter }}">Upload</label>
-
       </p>
     </div>
+
 
     <div class="input-field col s12 m5 l5 xl5" id="data-link-div-{{ counter }}">
       <a class="tooltipped prefix"
@@ -74,6 +74,10 @@
       <label for="data-link-input-{{ counter }}">
         Data File URL
       </label>
+      <input id="box-uid-data-{{ counter }}"
+             name="fields[data][{{ counter}}][boxuid]"
+             type="hidden"
+             value="null">
     </div>
 
 
@@ -83,7 +87,7 @@
         <input
           name="data-upload-input-file"
           id='data-upload-input-file-{{ counter }}'
-          onchange="send_to_box('#data-link-input-{{ counter }}', this)"
+          onchange="send_to_box('#data-link-input-{{ counter }}', this, '#box-uid-data-{{ counter }}')"
           type="file">
       </div>
       <div class="file-path-wrapper">

--- a/_includes/media_input.html
+++ b/_includes/media_input.html
@@ -62,6 +62,10 @@
       <label for="media-link-input-{{ counter }}">
         Media File URL
       </label>
+      <input id="box-uid-media-{{ counter }}"
+             name="fields[data][{{ counter}}][boxuid]"
+             type="hidden"
+             value="null">
     </div>
 
     <div hidden class="file-field input-field col s12 m5 l5 xl5" id="media-upload-div-{{ counter }}">
@@ -70,7 +74,7 @@
         <input
           name="media-upload-input-file"
           id='media-upload-input-file-{{ counter }}'
-          onchange="send_to_box('#media-link-input-{{ counter }}', this)"
+          onchange="send_to_box('#media-link-input-{{ counter }}', this, '#box-uid-media-{{ counter }}')"
           type="file">
       </div>
       <div class="file-path-wrapper">

--- a/simulations/upload_form.html
+++ b/simulations/upload_form.html
@@ -60,7 +60,8 @@ layout: default
             <p>
               <button class="btn waves-effect waves-light light-green darken-1"
                       type="submit"
-                      name="action">
+                      name="action"
+                      id="upload-form-submit">
                 Submit
                 <i class="material-icons right">send</i>
               </button>


### PR DESCRIPTION
Address #1178 

 - grey out submission button on upload from until the box app returns the file link
 - set up a shared folder with the app in my own box account to view data
 - include the link to the view of the folder in the meta.yaml alongside the url download link

A comment will appear below when the live site is built. This normally
takes a few minutes.

**Remember to tear down the live site when merging or closing this
pull request.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1201)
<!-- Reviewable:end -->
