### PR TITLE
chore: update config to use heroku app

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ links:
   nist: https://www.nist.gov
   chimad: http://chimad.northwestern.edu/
   slack: https://pfhub.slack.com/
-  app: https://ace-thought-249120.appspot.com
+  app: https://pfhub.herokuapp.com
   box_app: https://pfhub-box.appspot.com
 
 


### PR DESCRIPTION
Use the app on Heroku

Moved the PFHub app from Google Cloud to Heroku. Why?

 - Google Cloud is more difficult to use then Heroku
 - Heroku isn't charging me anythong. I'm getting small charges from Google Cloud
 - Trying to configure caching for backend (memcache or related) to speed up the frontend. Seems easier on Heroku and doesn't seem to be free on Google Cloud anymore.
 - This is important for BM8 as we need to start uploading whole fields of data and doing some calculations on the backend and then pushing snippets of data to the frontend. Hope is to cache a lot of the large data sets.
 - The app lives at wd15/pfhub-app currently as it needs to be in a base GitHub directory to work with automated releases on Heroku.
 
I've tested locally and all seems to work, but worth checking that things are working when on Surge and the main site after this merge.

**Remember to tear down the live site when merging or closing this
pull request.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1239)
<!-- Reviewable:end -->
