### PR TITLE
refactor: speedup website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ links:
   nist: https://www.nist.gov
   chimad: http://chimad.northwestern.edu/
   slack: https://pfhub.slack.com/
-  app: https://ace-thought-249120.appspot.com
+  app: https://pfhub.herokuapp.com
   box_app: https://pfhub-box.appspot.com
 
 

--- a/_data/calc_size_of_data.py
+++ b/_data/calc_size_of_data.py
@@ -1,0 +1,81 @@
+"""Run this to check the size of all the data available in the
+simulation results. Will give a summary of data types and sizes by
+simulations and aggregated.
+
+"""
+
+from pathlib import Path
+import requests
+
+from toolz.curried import map as fmap
+from toolz.curried import filter as ffilter
+from toolz.curried import compose, groupby, valmap, merge
+import numpy as np
+from pandas import DataFrame, concat
+
+from migrate_yaml import get_yaml_data
+
+
+# number of bytes in a megabyte
+MBFACTOR = float(1 << 20)
+
+
+def sequence(*args):
+    """Compose functions in reverse
+    """
+    return compose(*args[::-1])
+
+
+# pylint: disable=invalid-name
+filesize_from_url = sequence(
+    lambda x: requests.head(x, allow_redirects=True),
+    lambda x: x.headers.get("content-length", 0),
+    lambda x: int(x) / MBFACTOR,
+)
+
+
+def filesize(filename):
+    """Return the size of file
+    """
+    return Path(filename).stat().st_size / MBFACTOR
+
+
+# pylint: disable=invalid-name
+sizes = sequence(
+    ffilter(lambda x: "url" in x),
+    fmap(lambda x: dict(size_mb=filesize_from_url(x["url"]), type=x["type"])),
+    groupby(lambda x: x["type"]),
+    valmap(lambda x: np.sum(list(fmap(lambda y: y["size_mb"], x)))),
+)
+
+
+def aggregate(data_meta):
+    """Given a meta data element return a dictionary of the aggregated
+    data type file sizes.
+    """
+    return merge(
+        dict(meta=filesize(data_meta[0]), name=Path(data_meta[0]).parts[-2]),
+        sizes(data_meta[1]["data"]),
+    )
+
+
+# pylint: disable=invalid-name
+dataframe = sequence(
+    fmap(aggregate),
+    list,
+    DataFrame,
+    lambda x: x.fillna(0.0),
+    lambda x: concat([x, x.sum(axis=1, numeric_only=True)], axis=1)
+    .rename(columns={0: "total"})
+    .sort_values("total", ascending=False),
+)
+
+
+if __name__ == "__main__":
+    data = list(get_yaml_data())
+    df = dataframe(data)
+    print(df.head())
+    print()
+    print(df.describe())
+    print()
+    print(df.sum(axis=0, numeric_only=True))

--- a/_includes/coffee/vega_extra.coffee
+++ b/_includes/coffee/vega_extra.coffee
@@ -8,9 +8,16 @@ to_app_url = (app_url, url) ->
 
 
 dl_load = (app_url, url) ->
+  ### First try loading directly and then try using the app as the app
+  is much slower.
+  ###
   try
-    dl.load({url:to_app_url(app_url, url)})
+    try
+      dl.load({url:url})
+    catch NetworkError
+      dl.load({url:to_app_url(app_url, url)})
   catch NetworkError
+    console.log("NetworkError for url: #{url}")
     []
 
 


### PR DESCRIPTION
Speed up web pages with simulation data by

 - Getting data directly from the download site rather than using the app if there is no CORS issue (still getting the data from the app when getting a CORS issue).
 - Caching the data using memcache in Heroku (up to 50MB allowed for free). Our totally data right now is only 12MB.
 - Current version of the Heroku app is [here](https://github.com/wd15/pfhub-app).

The data loading for the results pages should be quite a bit faster now. More to come for that in another PR.

**Remember to tear down the live site when merging or closing this
pull request.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/pfhub/1242)
<!-- Reviewable:end -->
