### PR TITLE
Use GitHub Actions for Surge push

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,0 +1,21 @@
+---
+# Launch a workflow to prompt workflows run from master. Required
+# as jobs launched via pull-requests do not have access to secrets.
+name: pullrequest
+on: [push, pull_request]
+jobs:
+  pullrequest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: save-pr
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          LOGIN: ${{ github.event.pull_request.user.login }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+          echo $LOGIN > ./pr/login
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,6 @@ before_cache:
 install:
   - nix-shell --pure --command "echo 'run nix-shell and exit'"
 before_script:
-  - export DOMAIN=random-cat-${TRAVIS_PULL_REQUEST}.surge.sh
-  - export SURGE_LOGIN="daniel.wheeler@nist.gov"
-  - export SURGE_TOKEN="fcab9043c16e76c558d16bf6dc380f79"
-  - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-       nix-shell --command "
-         rm -rf ./_site &&
-         jekyll build --baseurl '' &&
-         surge --project _site --domain ${DOMAIN} &&
-         ./_apps/data/curl.sh
-       ";
-    fi;
   - nix-shell _apps/data/shell.nix --pure --command "echo 'run nix-shell and exit'"
 script:
   - nix-shell --command "

--- a/NIX.md
+++ b/NIX.md
@@ -68,3 +68,9 @@ Then run
 
 Edit `node.nix` and replace `nodejs-4_x` with `nodejs` in the 5th
 line.
+
+### Upload Surge to Cachix
+
+    $ nix-env -iA cachix -f https://cachix.org/api/v1/install
+    $ cachix authtoken <TOKEN>
+    $ nix_build -E '(import ./shell-surge.nix {}).nativeBuildInputs' | cachix push pfhub-surge


### PR DESCRIPTION
Switch the Surge push to use GitHub Actions.

Fixes #1429 

The push occurs with an event that does not use a pull_request trigger, but a workflow_run trigger. This needed to be tested from master, not a pull request, see the new [surge.yml](https://github.com/usnistgov/pfhub/blob/master/.github/workflows/surge.yml) file on master. The pullrequest.yml file on this branch triggers the surge.yml workflow.

 - The comment back to the PR can be seen below.
 - I don't know how to update the Surge token (the current one is exposed), see https://github.com/sintaxi/surge/issues/491
 - The Nix Cache has been fixed and actually works now
 - The Surge teardown will be implemented in a separate PR

Replaces #1467 as had issues rebasing.

**Remember to tear down the live site when merging or closing this
pull request.**
