### PR TITLE
ci(actions): make pr artifact a reusable workflow

### DIFF
--- a/.github/workflows/pr-artifact.yml
+++ b/.github/workflows/pr-artifact.yml
@@ -1,0 +1,27 @@
+name: pr-artifact
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: string
+      login:
+        required: true
+        type: string
+
+jobs:
+  upload:
+    steps:
+      - name: save-pr
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          LOGIN: ${{ inputs.login }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+          echo $LOGIN > ./pr/login
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number
+          path: pr/

--- a/.github/workflows/pr-artifact.yml
+++ b/.github/workflows/pr-artifact.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   upload:
+    runs-on: ubuntu-latest
     steps:
       - name: save-pr
         env:

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 jobs:
   pullrequest-close:
-    uses: usnistgov/pfhub/.github/workflwos/pr-artifact.yml@workflow
+    uses: usnistgov/pfhub/.github/workflows/pr-artifact.yml@workflow
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 jobs:
   pullrequest-close:
-    uses: usnistgov/pfhub/.github/workflows/pr-artifact.yml@workflow
+    uses: pr-artifact.yml@workflow
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 jobs:
   pullrequest-close:
-    uses: ./pr-artifact.yml@workflow
+    uses: ./pr-artifact.yml
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 jobs:
   pullrequest-close:
-    uses: ./pr-artifact.yml
+    uses: ./pr-artifact.yml@workflow
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 jobs:
   pullrequest-close:
-    uses: pr-artifact.yml@workflow
+    uses: ./pr-artifact.yml
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -7,7 +7,7 @@ on:
     types: [closed]
 jobs:
   pullrequest-close:
-    uses: ./pr-artifact.yml
+    uses: ./.github/workflows/pr-artifact.yml
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest-close.yml
+++ b/.github/workflows/pullrequest-close.yml
@@ -7,17 +7,7 @@ on:
     types: [closed]
 jobs:
   pullrequest-close:
-    runs-on: ubuntu-latest
-    steps:
-      - name: save-pr
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-          LOGIN: ${{ github.event.pull_request.user.login }}
-        run: |
-          mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
-          echo $LOGIN > ./pr/login
-      - uses: actions/upload-artifact@v3
-        with:
-          name: pr_number
-          path: pr/
+    uses: usnistgov/pfhub/.github/workflwos/pr-artifact.yml@workflow
+    with:
+      login: ${{ github.event.pull_request.user.login }}
+      pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ name: pullrequest
 on: [push, pull_request]
 jobs:
   pullrequest:
-    uses: .github/workflows/pr-artifact.yml
+    uses: .github/workflows/pr-artifact.yml@workflow
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -2,7 +2,7 @@
 # Launch a workflow to prompt workflows run from master. Required
 # as jobs launched via pull-requests do not have access to secrets.
 name: pullrequest
-on: pull-request
+on: pull_request
 jobs:
   pullrequest:
     uses: ./.github/workflows/pr-artifact.yml

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ name: pullrequest
 on: [push, pull_request]
 jobs:
   pullrequest:
-    uses: .github/workflows/pr-artifact.yml@workflow
+    uses: ./.github/workflows/pr-artifact.yml@workflow
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ name: pullrequest
 on: [push, pull_request]
 jobs:
   pullrequest:
-    uses: pr-artifact.yml@workflow
+    uses: .github/workflows/pr-artifact.yml
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ name: pullrequest
 on: [push, pull_request]
 jobs:
   pullrequest:
-    uses: ./.github/workflows/pr-artifact.yml@workflow
+    uses: ./.github/workflows/pr-artifact.yml
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,7 +5,7 @@ name: pullrequest
 on: [push, pull_request]
 jobs:
   pullrequest:
-    uses: usnistgov/pfhub/.github/workflwos/pr-artifact.yml@workflow
+    uses: pr-artifact.yml@workflow
     with:
       login: ${{ github.event.pull_request.user.login }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -2,7 +2,7 @@
 # Launch a workflow to prompt workflows run from master. Required
 # as jobs launched via pull-requests do not have access to secrets.
 name: pullrequest
-on: [push, pull_request]
+on: pull-request
 jobs:
   pullrequest:
     uses: ./.github/workflows/pr-artifact.yml

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,17 +5,7 @@ name: pullrequest
 on: [push, pull_request]
 jobs:
   pullrequest:
-    runs-on: ubuntu-latest
-    steps:
-      - name: save-pr
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-          LOGIN: ${{ github.event.pull_request.user.login }}
-        run: |
-          mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
-          echo $LOGIN > ./pr/login
-      - uses: actions/upload-artifact@v3
-        with:
-          name: pr_number
-          path: pr/
+    uses: usnistgov/pfhub/.github/workflwos/pr-artifact.yml@workflow
+    with:
+      login: ${{ github.event.pull_request.user.login }}
+      pr_number: ${{ github.event.number }}


### PR DESCRIPTION
Make the upload steps in pullrequest.yml and pullrequest-close.yml a reusable workflow.

**A one line, short summary of intent.**

Links to issues such as "Fixes #XXX" or "Addresses #XXX".

A longer description and justification for the changes.

Raise any areas of concern.

A comment will appear below when the live site is built. This normally
takes a few minutes.
